### PR TITLE
Add facebook token sign in

### DIFF
--- a/src/Nether.Web/Features/CookieAuth/CookieAuthController.cs
+++ b/src/Nether.Web/Features/CookieAuth/CookieAuthController.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+// For more information on enabling Web API for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace Nether.Web.Features.CookieAuth
+{
+    //
+    // TODO !!!!!!!!!!!!!!!!!!!!!
+    // This is a quick implementation of authentication using cookies
+    // We should switch to Bearer Tokens. Auth0 has a nice write-up here: https://auth0.com/blog/cookies-vs-tokens-definitive-guide/
+    // The token issuer middleware is no longer in ASP.NET Core, so we should look at Azure Active Directory B2C and Identity Server
+    //
+
+    [Route("cookie-auth")]
+    public class CookieAuthController : Controller
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<CookieAuthController> _logger;
+
+        public CookieAuthController(IConfiguration configuration, ILoggerFactory loggerFactory)
+        {
+            _configuration = configuration; // TODO - review config
+            _logger = loggerFactory.CreateLogger<CookieAuthController>();
+        }
+
+        [HttpPost("sign-in/facebook")]
+        public async Task<IActionResult> FacebookSignIn([FromBody] FacebookSignInModel model)
+        {
+            var appToken = _configuration["Facebook:AppToken"];
+
+            // TODO - reuse HttpClient
+            var client = new HttpClient()
+            {
+                BaseAddress = new Uri("https://graph.facebook.com/"),
+                DefaultRequestHeaders =
+                {
+                    Accept =
+                    {
+                        new MediaTypeWithQualityHeaderValue("application/json")
+                    }
+                }
+            };
+
+            var response = await client.GetAsync($"/debug_token?input_token={model.UserAccessToken}&access_token={appToken}");
+
+            dynamic body = await response.Content.ReadAsAsync<dynamic>();
+
+            if (body.data == null)
+            {
+                // Get here if (for example) the token is for a different application
+                var message = (string)body.error.message;
+                _logger.LogError("FacebookSignIn: error validating token: {0}", message);
+                return BadRequest();
+            }
+
+            bool isValid = (bool)body.data.is_valid;
+            var userId = (string)body.data.user_id;
+            if (!isValid)
+            {
+                var message = (string)body.data.error.message;
+                _logger.LogDebug("FacebookSignIn: invalid token: {0}", message);
+                return StatusCode((int)HttpStatusCode.Unauthorized);
+            }
+            _logger.LogDebug("FacebookSignIn: Signing in: {0}", userId);
+
+            var scopes = ((JArray)body.data.scopes).Select(t => t.Value<string>());
+            ClaimsPrincipal principal = new ClaimsPrincipal(
+               new ClaimsIdentity(
+                   new[]
+                   {
+                        new Claim(ClaimTypes.Name, $"fb-{userId}"), // TODO - need to figure out what user name should be. Gamertag? How to look up??
+                        new Claim(ClaimTypes.NameIdentifier, userId),
+                        new Claim(ClaimTypes.Role, "player"),
+                   },
+                   "nether-facebook"
+               )
+            );
+            var authenticationProperties = new AuthenticationProperties()
+            {
+                Items =
+                {
+                    { "scopes", string.Join(",", scopes)},
+                    { "userAccessToken", model.UserAccessToken }
+                }
+            };
+            await HttpContext.Authentication.SignInAsync("NetherCookieAuth", principal, authenticationProperties);
+
+            return Ok();
+        }
+
+        [Authorize]
+        [HttpGet("sign-out")]
+        public async Task<IActionResult> SignOut()
+        {
+            await HttpContext.Authentication.SignOutAsync("NetherCookieAuth");
+            return Ok();
+        }
+
+
+
+#if DEBUG
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////
+        //               ____  _____ __  __  _____     _______   _____ _   _ ___ ____ _
+        //              |  _ \| ____|  \/  |/ _ \ \   / / ____| |_   _| | | |_ _/ ___|| |
+        //              | |_) |  _| | |\/| | | | \ \ / /|  _|     | | | |_| || |\___ \| |
+        //              | _ < | |___| |  | | |_| |\ V / | |___    | | |  _  || | ___) |_|
+        //              |_| \_\_____|_|  |_|\___/  \_/  |_____|   |_| |_| |_|___|____/(_)
+        //
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        [Authorize]
+        [HttpGet("/dev-mode/show-info")]
+
+        public async Task<IActionResult> DevModeShowInfo() //////////////////////////////////////TODO - REMOVE THIS!!! REMOVE THIS!!! REMOVE THIS!!! REMOVE THIS!!! REMOVE THIS!!! ////////////////////////
+        {
+            var info = await HttpContext.Authentication.GetAuthenticateInfoAsync("NetherCookieAuth");
+            return Ok(
+                new
+                {
+                    username = User.Identity.Name,
+                    claims = User.Claims.ToDictionary(c => c.Type, c => c.Value),
+                    properties = info.Properties.Items
+                });
+        }
+#endif
+    }
+}

--- a/src/Nether.Web/Features/CookieAuth/FacebookSignInModel.cs
+++ b/src/Nether.Web/Features/CookieAuth/FacebookSignInModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nether.Web.Features.CookieAuth
+{
+    public class FacebookSignInModel
+    {
+        public string UserAccessToken { get; set; }
+    }
+}

--- a/src/Nether.Web/Startup.cs
+++ b/src/Nether.Web/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,6 +45,16 @@ namespace Nether.Web
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
+
+
+            app.UseCookieAuthentication(new CookieAuthenticationOptions()
+            {
+                AuthenticationScheme = "NetherCookieAuth",
+                LoginPath = new PathString("/Account/Unauthorized/"),
+                AccessDeniedPath = new PathString("/Account/Forbidden/"),
+                AutomaticAuthenticate = true,
+                AutomaticChallenge = false
+            });
 
             app.UseMvc();
             app.UseSwagger(routeTemplate: "api/swagger/{apiVersion}/swagger.json");

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -7,6 +7,9 @@
       "Microsoft": "Information"
     }
   },
+  "Facebook": {
+    "AppToken": ""
+  },
   // Add these configuration values via environment variables or override on deployment
   "EventHub": {
     "KeyName": "",

--- a/src/Nether.Web/project.json
+++ b/src/Nether.Web/project.json
@@ -19,7 +19,11 @@
     "Nether.Data.MongoDB": "1.0.0-*",
     "Nether.Common.DependencyInjection": "1.0.0-*",
     "Nether.Integration": "1.0.0-*",
-    "Nether.Integration.Default": "1.0.0-*"
+    "Nether.Integration.Default": "1.0.0-*",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
+    "Microsoft.AspNet.WebApi.Client": "5.2.3",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "System.Runtime.Serialization.Xml": "4.1.1"
   },
 
   "tools": {


### PR DESCRIPTION
Add endpoint to turn facebook user token into cookie

This is only intended as an interim solution until we get bearer token support sorted.

This also doesn't handle setting the user id to the player gamertag. Currently is uses the facebook userid
