### PR TITLE
Reomve unused APIs from leaderboard controller

### DIFF
--- a/src/Nether.Web/Features/Leaderboard/LeaderboardController.cs
+++ b/src/Nether.Web/Features/Leaderboard/LeaderboardController.cs
@@ -71,7 +71,7 @@ namespace Nether.Web.Features.Leaderboard
             // Return result
             return Ok(resultModel);
         }
-        
+
         [Authorize]
         [HttpPost]
         public async Task<ActionResult> Post([FromBody]LeaderboardPostRequestModel score)


### PR DESCRIPTION
 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Remove unused APIs from the leaderboard controller. All is used is a GET API with the leaderboard type as parameter.
