### PR TITLE
Split config into sections per service/feature

### DIFF
--- a/src/Common/Nether.Common.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Common/Nether.Common.DependencyInjection/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Nether.Common.DependencyInjection
             }
             else
             {
-                throw new ArgumentException("No valid configuration found for '{serviceName}'");
+                throw new ArgumentException($"No valid configuration found for '{serviceName}'");
             }
         }
 

--- a/src/Nether.Web/Features/Analytics/AnalyticsServiceExtensions.cs
+++ b/src/Nether.Web/Features/Analytics/AnalyticsServiceExtensions.cs
@@ -14,37 +14,7 @@ namespace Nether.Web.Features.Analytics
     {
         public static IServiceCollection AddAnalyticsServices(this IServiceCollection services, IConfiguration configuration)
         {
-            // TODO - look at what can be extracted to generalise this
-            if (configuration.Exists("AnalyticsIntegrationClient:wellKnown"))
-            {
-                // register using well-known type
-                var wellKnownType = configuration["AnalyticsIntegrationClient:wellknown"];
-                switch (wellKnownType)
-                {
-                    case "null":
-                        services.AddSingleton<IAnalyticsIntegrationClient, AnalyticsIntegrationNullClient>();
-                        break;
-                    case "default":
-                        var scopedConfiguration = configuration.GetSection("AnalyticsIntegrationClient:properties");
-                        string baseUrl = scopedConfiguration["AnalyticsBaseUrl"];
-
-                        services.AddTransient<IAnalyticsIntegrationClient>(serviceProvider =>
-                        {
-                            return new AnalyticsIntegrationClient(baseUrl);
-                        });
-                        break;
-                    default:
-                        throw new Exception($"Unhandled 'wellKnown' type for AnalyticsIntegrationClient: '{wellKnownType}'");
-                }
-            }
-            else
-            {
-                // fall back to generic "factory"/"implementation" configuration
-                services.AddServiceFromConfiguration<IAnalyticsIntegrationClient>(configuration, "AnalyticsIntegrationClient");
-            }
-
-
-            services.AddEndpointInfo(configuration, "EventHub");
+            services.AddEndpointInfo(configuration, "Analytics:EventHub");
 
             return services;
         }

--- a/src/Nether.Web/Features/Identity/FacebookUserAccessTokenExtensionGrantValidator.cs
+++ b/src/Nether.Web/Features/Identity/FacebookUserAccessTokenExtensionGrantValidator.cs
@@ -42,7 +42,7 @@ namespace Nether.Web.Features.Identity
 
             // TODO - refactor this code as there's a lot going on here!
 
-            var appToken = _configuration["Facebook:AppToken"];
+            var appToken = _configuration["Identity:Facebook:AppToken"];
 
             var token = context.Request.Raw["token"];
 

--- a/src/Nether.Web/Features/PlayerManagement/PlayerManagementServiceExtensions.cs
+++ b/src/Nether.Web/Features/PlayerManagement/PlayerManagementServiceExtensions.cs
@@ -17,14 +17,14 @@ namespace Nether.Web.Features.PlayerManagement
         public static IServiceCollection AddPlayerManagementServices(this IServiceCollection services, IConfiguration configuration)
         {
             // TODO - look at what can be extracted to generalise this
-            if (configuration.Exists("PlayerManagementStore:wellKnown"))
+            if (configuration.Exists("PlayerManagement:Store:wellKnown"))
             {
                 // register using well-known type
-                var wellKnownType = configuration["PlayerManagementStore:wellknown"];
+                var wellKnownType = configuration["PlayerManagement:Store:wellknown"];
                 switch (wellKnownType)
                 {
                     case "mongo":
-                        var scopedConfiguration = configuration.GetSection("PlayerManagementStore:properties");
+                        var scopedConfiguration = configuration.GetSection("PlayerManagement:Store:properties");
                         string connectionString = scopedConfiguration["ConnectionString"];
                         string databaseName = scopedConfiguration["DatabaseName"];
 
@@ -36,13 +36,13 @@ namespace Nether.Web.Features.PlayerManagement
                         });
                         break;
                     default:
-                        throw new Exception($"Unhandled 'wellKnown' type for PlayerManagementStore: '{wellKnownType}'");
+                        throw new Exception($"Unhandled 'wellKnown' type for PlayerManagement:Store: '{wellKnownType}'");
                 }
             }
             else
             {
                 // fall back to generic "factory"/"implementation" configuration
-                services.AddServiceFromConfiguration<IPlayerManagementStore>(configuration, "PlayerManagementStore");
+                services.AddServiceFromConfiguration<IPlayerManagementStore>(configuration, "PlayerManagement:Store");
             }
             return services;
         }

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -1,44 +1,71 @@
 ﻿{
-   "Logging": {
-      "IncludeScopes": false,
-      "LogLevel": {
-         "Default": "Debug",
-         "System": "Information",
-         "Microsoft": "Information"
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+
+
+  "Leaderboard": {
+    "Store": {
+      "wellknown": "sql",
+      "properties": {
+        "ConnectionString": "<sql connection string here>"
       }
-   },
-   "Facebook": {
+    },
+    "AnalyticsIntegrationClient": {
+      "wellknown": "null",
+      "properties": {
+        "AnalyticsBaseUrl": "http://localhost:5000/api/"
+      }
+    }
+    // "AnalyticsIntegrationClient": {
+    //   "wellknown": "null"
+    // }
+    // Thoughts on leaderboard config:
+    // "Leaderboards": [
+    //   {
+    //     "Name": "default",
+    //     "Type": "top",
+    //     "Top": 10
+    //   },
+    //   {
+    //     "Name": "rank",
+    //     "Type": "aroundme",
+    //     "Radius": 5
+    //   }
+    // ]
+  },
+
+
+  "Identity": {
+    "Facebook": {
       "AppToken": ""
-   },
-   // Add these configuration values via environment variables or override on deployment
-   "EventHub": {
+    }
+  },
+
+
+  "Analytics": {
+    // Add these configuration values via environment variables or override on deployment
+    "EventHub": {
       "KeyName": "",
       "AccessKey": "",
       "Resource": "",
       "Ttl": "24:00:00"
-   },
+    }
+  },
 
-   "LeaderboardStore": {
-      "wellknown": "sql",
-      "properties": {
-         "ConnectionString": "<sql connection string here>"
-      }
-   },
-   "PlayerManagementStore": {
+
+  "PlayerManagement": {
+    "Store": {
       "wellknown": "mongo",
       "properties": {
-         "ConnectionString": "mongodb://localhost:27017",
-         "DatabaseName": "players"
+        "ConnectionString": "mongodb://localhost:27017",
+        "DatabaseName": "players"
       }
-   },
-
-   "AnalyticsIntegrationClient": {
-      "wellknown": "null",
-      "properties": {
-         "AnalyticsBaseUrl": "http://localhost:5000/api/"
-      }
-   }
-   // "AnalyticsIntegrationClient": {
-   //   "wellknown": "null"
-   // }
+    }
+  }
 }


### PR DESCRIPTION
### Issue: #22

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Split the config into separate top level sections as discussed in London. This would also make it easier to split the config for each service into separate files if that it something that we wanted to do.

### Test:
Run the integration tests. Note that any scripts that set up environment variables to override config will need updating
