### PR TITLE
Game Events should include generic property "Properties"

### DIFF
--- a/src/Nether.Analytics.EventProcessor/GameEventHandler.cs
+++ b/src/Nether.Analytics.EventProcessor/GameEventHandler.cs
@@ -89,6 +89,13 @@ namespace Nether.Analytics.EventProcessor
             _blobOutputManager.AppendLineToBlob(gameEventType, csvEvent);
         }
 
+        public void HandleGenericEvent(string gameEventType, string jsonEvent)
+        {
+            var csvEvent = jsonEvent.JsonToCsvString("type", "version");
+
+            _blobOutputManager.AppendLineToBlob(gameEventType, csvEvent);
+        }
+
         #endregion
 
 

--- a/src/Nether.Analytics.EventProcessor/GameEventRouter.cs
+++ b/src/Nether.Analytics.EventProcessor/GameEventRouter.cs
@@ -73,11 +73,9 @@ namespace Nether.Analytics.EventProcessor
                 return;
             }
 
-            // Get correct game event handler from dictionary of registered handlers
-            var handler = _gameEventTypeActions[type];
 
             // Check if game event type is known
-            if (handler == null)
+            if (!_gameEventTypeActions.ContainsKey(type))
             {
                 // No registered action found for the found Game Event Type
                 // Invoke action to handle Unknown Game Event Type if registered (not null)
@@ -87,6 +85,8 @@ namespace Nether.Analytics.EventProcessor
                 return;
             }
 
+            // Get correct game event handler from dictionary of registered handlers
+            var handler = _gameEventTypeActions[type];
             // Pass game event data to correct action
             handler(type, data);
         }

--- a/src/Nether.Analytics.EventProcessor/Output/Blob/BlobOutputManager.cs
+++ b/src/Nether.Analytics.EventProcessor/Output/Blob/BlobOutputManager.cs
@@ -51,6 +51,8 @@ namespace Nether.Analytics.EventProcessor.Output.Blob
                     }
                 }
 
+                Console.WriteLine($"Write to [{blobName}]: {data}");
+
                 blob.AppendText(data + "\n", accessCondition: AccessCondition.GenerateIfMaxSizeLessThanOrEqualCondition(_maxBlobSize));
             }
             //TODO: Figure out exactly what exception is thrown if blob is too big and only catch that

--- a/src/Nether.Analytics.GameEvents/CountEvent.cs
+++ b/src/Nether.Analytics.GameEvents/CountEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -13,5 +14,6 @@ namespace Nether.Analytics.GameEvents
         public string DisplayName { get; set; }
         public int Value { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/GameHeartbeatEvent.cs
+++ b/src/Nether.Analytics.GameEvents/GameHeartbeatEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -11,5 +12,6 @@ namespace Nether.Analytics.GameEvents
         public string Version => "1.0.0";
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/GameStartEvent.cs
+++ b/src/Nether.Analytics.GameEvents/GameStartEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -12,5 +13,6 @@ namespace Nether.Analytics.GameEvents
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
         public string GamerTag { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/GameStopEvent.cs
+++ b/src/Nether.Analytics.GameEvents/GameStopEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -11,5 +12,6 @@ namespace Nether.Analytics.GameEvents
         public string Version => "1.0.0";
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/GenericEvent.cs
+++ b/src/Nether.Analytics.GameEvents/GenericEvent.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Nether.Analytics.GameEvents/GenericEvent.cs
+++ b/src/Nether.Analytics.GameEvents/GenericEvent.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Nether.Analytics.GameEvents
+{
+    public class GenericEvent : IGameEvent
+    {
+        public string Type => "generic";
+        public string Version => "1.0.0";
+        public DateTime ClientUtcTime { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
+    }
+}

--- a/src/Nether.Analytics.GameEvents/IGameEvent.cs
+++ b/src/Nether.Analytics.GameEvents/IGameEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -10,5 +11,6 @@ namespace Nether.Analytics.GameEvents
         string Type { get; }
         string Version { get; }
         DateTime ClientUtcTime { get; set; }
+        Dictionary<string, string> Properties { get; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/LocationEvent.cs
+++ b/src/Nether.Analytics.GameEvents/LocationEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -11,5 +12,6 @@ namespace Nether.Analytics.GameEvents
         public string Version => "1.0.0";
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/ScoreEvent.cs
+++ b/src/Nether.Analytics.GameEvents/ScoreEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -12,5 +13,6 @@ namespace Nether.Analytics.GameEvents
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
         public long Score { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/StartEvent.cs
+++ b/src/Nether.Analytics.GameEvents/StartEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
@@ -13,5 +14,6 @@ namespace Nether.Analytics.GameEvents
         public string EventCorrelationId { get; set; }
         public string DisplayName { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/Nether.Analytics.GameEvents/StopEvent.cs
+++ b/src/Nether.Analytics.GameEvents/StopEvent.cs
@@ -2,15 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
-    public class StoppEvent : IGameEvent
+    public class StopEvent : IGameEvent
     {
         public string Type => "stop";
         public string Version => "1.0.0";
         public DateTime ClientUtcTime { get; set; }
         public string EventCorrelationId { get; set; }
         public string GameSessionId { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/TestClients/AnalyticsTestClient/SendTypedGameEventMenu.cs
+++ b/src/TestClients/AnalyticsTestClient/SendTypedGameEventMenu.cs
@@ -60,7 +60,9 @@ namespace AnalyticsTestClient.Utils
         {
             gameEvent.ClientUtcTime = DateTime.UtcNow;
 
-            foreach (var prop in gameEvent.GetType().GetProperties())
+            var props = gameEvent.GetType().GetProperties();
+
+            foreach (var prop in props)
             {
                 var propName = prop.Name;
                 if (propName != "ClientUtcTime" && Program.PropertyCache.ContainsKey(propName))
@@ -81,103 +83,8 @@ namespace AnalyticsTestClient.Utils
                     var o = EditProperty(propName, propValue, propertyType);
                     prop.SetValue(gameEvent, o);
                     Program.PropertyCache[propName] = o;
-
-                    //Console.Write($"{propName} [{propValue}]:");
-                    //var answer = Console.ReadLine();
-                    //if (!string.IsNullOrWhiteSpace(answer))
-                    //{
-                    //    if (prop.PropertyType == typeof(int))
-                    //    {
-                    //        int i = int.Parse(answer);
-                    //        prop.SetValue(gameEvent, i);
-                    //        Program.PropertyCache[propName] = i;
-                    //    }
-                    //    else if (prop.PropertyType == typeof(long))
-                    //    {
-                    //        long l = long.Parse(answer);
-                    //        prop.SetValue(gameEvent, l);
-                    //        Program.PropertyCache[propName] = l;
-                    //    }
-                    //    else if (prop.PropertyType == typeof(DateTime))
-                    //    {
-                    //        DateTime dt = DateTime.Parse(answer);
-                    //        prop.SetValue(gameEvent, dt);
-                    //        Program.PropertyCache[propName] = dt;
-                    //    }
-                    //    else
-                    //    {
-                    //        // If nothing else, use string directly
-                    //        prop.SetValue(gameEvent, answer);
-                    //        Program.PropertyCache[propName] = answer;
-                    //    }
-                    //}
                 }
             }
         }
-        //private static void EditGameEventPropertiesAndSend(IGameEvent ge)
-        //{
-        //    Console.WriteLine("Fill out property values for Game Event. Press <Enter> to keep current/default value.");
-        //    ge.ClientUtcTime = DateTime.UtcNow;
-
-        //    //var gameEvent = new T {ClientUtcTime = DateTime.UtcNow};
-
-        //    foreach (var prop in ge.GetType().GetProperties())
-        //    {
-        //        var propName = prop.Name;
-        //        if (PropertyCache.ContainsKey(propName))
-        //        {
-        //            prop.SetValue(ge, PropertyCache[propName]);
-        //        }
-        //        var propValue = prop.GetValue(ge);
-
-        //        if (propName == "GameEventType" || propName == "Version")
-        //        {
-        //            // Don't ask for input for these properties, just display their 
-        //            // values since they are static and can't be changed
-        //            Console.WriteLine($"{propName}: {propValue}");
-        //        }
-        //        else
-        //        {
-        //            Console.Write($"{propName} [{propValue}]:");
-        //            var answer = Console.ReadLine();
-        //            if (!string.IsNullOrWhiteSpace(answer))
-        //            {
-        //                if (prop.PropertyType == typeof(int))
-        //                {
-        //                    int i = int.Parse(answer);
-        //                    prop.SetValue(ge, i);
-        //                    PropertyCache[propName] = i;
-        //                }
-        //                else if (prop.PropertyType == typeof(long))
-        //                {
-        //                    long l = long.Parse(answer);
-        //                    prop.SetValue(ge, l);
-        //                    PropertyCache[propName] = l;
-        //                }
-        //                else if (prop.PropertyType == typeof(DateTime))
-        //                {
-        //                    DateTime dt = DateTime.Parse(answer);
-        //                    prop.SetValue(ge, dt);
-        //                    PropertyCache[propName] = dt;
-        //                }
-        //                else
-        //                {
-        //                    // If nothing else, use string directly
-        //                    prop.SetValue(ge, answer);
-        //                    PropertyCache[propName] = answer;
-        //                }
-        //            }
-        //        }
-        //    }
-
-        //    var json = JsonConvert.SerializeObject(ge);
-
-        //    Console.WriteLine(json);
-
-        //    SendMessageToEventHub(json).Wait();
-
-        //    SendKnownMessageMenu();
-        //}
-
     }
 }

--- a/src/TestClients/AnalyticsTestClient/Utils/ConsoleMenu.cs
+++ b/src/TestClients/AnalyticsTestClient/Utils/ConsoleMenu.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection.Metadata.Ecma335;
 
 namespace AnalyticsTestClient.Utils
 {
@@ -64,8 +65,44 @@ namespace AnalyticsTestClient.Utils
         {
         }
 
+        public Dictionary<string, string> EditDictionary(string propertyName)
+        {
+            Console.WriteLine($"Fill {propertyName} with key value pairs. End with empty key.");
+
+            var dict = new Dictionary<string, string>();
+            int i = 1;
+
+            while (true)
+            {
+                Console.Write($"  Key{i++}: ");
+                var key = Console.ReadLine();
+
+                if (string.IsNullOrWhiteSpace(key))
+                    break;
+                else if (dict.ContainsKey(key))
+                {
+                    Console.WriteLine("    Can't add a key that already exists");
+                    continue;
+                }
+
+                Console.Write($"  Value: ");
+                var value = Console.ReadLine();
+
+                dict.Add(key, value);
+            }
+
+            return dict;
+        }
+
         public object EditProperty(string propertyName, object o, Type propertyType)
         {
+            //TODO: ReFactor to have different methods per property type
+
+            if (propertyType == typeof(Dictionary<string, string>))
+            {
+                return EditDictionary(propertyName);
+            }
+
             while (true)
             {
                 Console.Write($"{propertyName} [{o}]: ");


### PR DESCRIPTION
### Issue: #280 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Game Events should include property "Properties" that allows game client to send additional information as part of the game events to Nether Analytics. This property should be seen as optional.

### Test:

Same tests as for https://github.com/MicrosoftDX/nether/pull/268 except that Game Events (and the AnalyticsTestClient) now supports generic data being passed in property "Properties"
