### PR TITLE
Leaderboard rank - handle duplicate scores

### DIFF
--- a/src/Nether.Data.Sql.Schema/GetHighScores.sql
+++ b/src/Nether.Data.Sql.Schema/GetHighScores.sql
@@ -5,25 +5,25 @@ CREATE PROCEDURE [dbo].[GetHighScores]
 	@StartRank int = 0,
 	@Count int
 AS
-SELECT 
-	Score, 
-	Gamertag, 
-	CustomTag, 
-	Ranking 
+SELECT
+	Score,
+	Gamertag,
+	CustomTag,
+	Ranking
 FROM
-	(SELECT 
-		Score, 
-		Gamertag, 
-		CustomTag, 
-		ROW_NUMBER() OVER(ORDER BY Score DESC) AS Ranking 
+	(SELECT
+		Score,
+		Gamertag,
+		CustomTag,
+		RANK() OVER(ORDER BY Score DESC) AS Ranking
 		FROM (
-			SELECT 
-				Gamertag, 
-				MAX(Score) AS Score, 
-				MAX(CustomTag) AS CustomTag 
-			FROM Scores 
+			SELECT
+				Gamertag,
+				MAX(Score) AS Score,
+				MAX(CustomTag) AS CustomTag
+			FROM Scores
 			GROUP BY GamerTag
-		) AS T 
+		) AS T
 	) AS T2
 WHERE Ranking BETWEEN @StartRank AND (@StartRank + @Count)
 ORDER BY Score DESC

--- a/src/Nether.Data.Sql.Schema/GetPlayerRank.sql
+++ b/src/Nether.Data.Sql.Schema/GetPlayerRank.sql
@@ -3,21 +3,21 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
 CREATE PROCEDURE [dbo].GetPlayerRank
 	@Gamertag NVARCHAR(50),
-	@Rank INT OUTPUT 
+	@Rank INT OUTPUT
 AS
 SET @Rank = -1
 
-SELECT 
-	@Rank = Ranking 
+SELECT
+	@Rank = Ranking
 FROM (
-	SELECT 
-		Gamertag, 
-		MAX(Score) AS Score, 
-		MAX(CustomTag) AS CustomTag, 
-		ROW_NUMBER() OVER (ORDER BY MAX(Score) DESC) AS Ranking 
-	FROM Scores 
+	SELECT
+		Gamertag,
+		MAX(Score) AS Score,
+		MAX(CustomTag) AS CustomTag,
+		RANK() OVER (ORDER BY MAX(Score) DESC) AS Ranking
+	FROM Scores
 	GROUP BY Gamertag
-) AS T 
+) AS T
 WHERE Gamertag = @Gamertag
 
 RETURN 0

--- a/src/Nether.Data.Sql.Schema/GetScoresAroundPlayer.sql
+++ b/src/Nether.Data.Sql.Schema/GetScoresAroundPlayer.sql
@@ -21,7 +21,7 @@ BEGIN
 			Gamertag,
 			MAX(Score) AS Score,
 			MAX(CustomTag) AS CustomTag,
-			ROW_NUMBER() OVER (ORDER BY MAX(Score) DESC) AS Ranking
+			RANK() OVER (ORDER BY MAX(Score) DESC) AS Ranking
 		FROM Scores
 		GROUP BY GamerTag
 	) AS T

--- a/src/Nether.Data.Sql.Schema/GetScoresAroundPlayer.sql
+++ b/src/Nether.Data.Sql.Schema/GetScoresAroundPlayer.sql
@@ -26,6 +26,7 @@ BEGIN
 		GROUP BY GamerTag
 	) AS T
 	WHERE Ranking BETWEEN (@PlayerRank-@Radius) AND (@PlayerRank + @Radius)
+	ORDER BY Ranking, GamerTag
 END
 ELSE
 BEGIN

--- a/src/Nether.Data.Sql/Leaderboard/InMemoryLeaderboardContext.cs
+++ b/src/Nether.Data.Sql/Leaderboard/InMemoryLeaderboardContext.cs
@@ -76,7 +76,7 @@ namespace Nether.Data.Sql.Leaderboard
             // now sort the list and track the ROW_NUMBER
             var sortedBestScoreListWithIndex = bestScoreList
                     .OrderByDescending(s => s.Score)
-                    .Select((s, index)=> new
+                    .Select((s, index) => new
                     {
                         s.Gamertag,
                         s.CustomTag,
@@ -103,7 +103,6 @@ namespace Nether.Data.Sql.Leaderboard
                 CustomTag = p.CustomTag
             })).ToList();
         }
-
     }
 }
 

--- a/src/Nether.Web/Features/Leaderboard/Models/Leaderboard/LeaderboardGetResponseModel.cs
+++ b/src/Nether.Web/Features/Leaderboard/Models/Leaderboard/LeaderboardGetResponseModel.cs
@@ -20,6 +20,9 @@ namespace Nether.Web.Features.Leaderboard.Models.Leaderboard
         {
             public static LeaderboardEntry Map(GameScore score, string currentGamertag)
             {
+                if (score == null)
+                    return null;
+
                 return new LeaderboardEntry
                 {
                     Gamertag = score.Gamertag,

--- a/tests/Nether.Web.IntegrationTests/Leaderboard/LeaderboardTests.cs
+++ b/tests/Nether.Web.IntegrationTests/Leaderboard/LeaderboardTests.cs
@@ -98,19 +98,38 @@ namespace Nether.Web.IntegrationTests.Leaderboard
 
             var response = await GetLeaderboardAsync(client, leaderboardName);
             Assert.Collection(response.Entries,
-                entry => Assert.Equal("testuser12", entry.Gamertag),
-                entry => Assert.Equal("testuser11", entry.Gamertag),
-                entry => Assert.Equal("testuser10", entry.Gamertag),
-                entry => Assert.Equal("testuser9", entry.Gamertag),
-                entry => Assert.Equal("testuser8", entry.Gamertag),
-                entry => Assert.Equal("testuser", entry.Gamertag),
-                entry => Assert.Equal("testuser7", entry.Gamertag),
-                entry => Assert.Equal("testuser6", entry.Gamertag),
-                entry => Assert.Equal("testuser5", entry.Gamertag),
-                entry => Assert.Equal("testuser4", entry.Gamertag),
-                entry => Assert.Equal("testuser3", entry.Gamertag)
+                entry => { Assert.Equal("testuser12", entry.Gamertag); Assert.Equal(1, entry.Rank); },
+                entry => { Assert.Equal("testuser11", entry.Gamertag); Assert.Equal(2, entry.Rank); },
+                entry => { Assert.Equal("testuser10", entry.Gamertag); Assert.Equal(3, entry.Rank); },
+                entry => { Assert.Equal("testuser9", entry.Gamertag); Assert.Equal(4, entry.Rank); },
+                entry => { Assert.Equal("testuser8", entry.Gamertag); Assert.Equal(5, entry.Rank); },
+                entry => { Assert.Equal("testuser", entry.Gamertag); Assert.Equal(6, entry.Rank); },
+                entry => { Assert.Equal("testuser7", entry.Gamertag); Assert.Equal(7, entry.Rank); },
+                entry => { Assert.Equal("testuser6", entry.Gamertag); Assert.Equal(8, entry.Rank); },
+                entry => { Assert.Equal("testuser5", entry.Gamertag); Assert.Equal(9, entry.Rank); },
+                entry => { Assert.Equal("testuser4", entry.Gamertag); Assert.Equal(10, entry.Rank); },
+                entry => { Assert.Equal("testuser3", entry.Gamertag); Assert.Equal(11, entry.Rank); }
              );
 
+
+            // update score to one that matches another score
+            await PostScoreAsync(client, 900);
+            response = await GetLeaderboardAsync(client, leaderboardName);
+            Assert.Collection(response.Entries,
+                entry => { Assert.Equal("testuser12", entry.Gamertag); Assert.Equal(1, entry.Rank); },
+                entry => { Assert.Equal("testuser11", entry.Gamertag); Assert.Equal(2, entry.Rank); },
+                entry => { Assert.Equal("testuser10", entry.Gamertag); Assert.Equal(3, entry.Rank); },
+                entry => { Assert.Equal("testuser", entry.Gamertag); Assert.Equal(4, entry.Rank); }, // note equal to rank below
+                entry => { Assert.Equal("testuser9", entry.Gamertag); Assert.Equal(4, entry.Rank); },
+                entry => { Assert.Equal("testuser8", entry.Gamertag); Assert.Equal(6, entry.Rank); },
+                entry => { Assert.Equal("testuser7", entry.Gamertag); Assert.Equal(7, entry.Rank); },
+                entry => { Assert.Equal("testuser6", entry.Gamertag); Assert.Equal(8, entry.Rank); },
+                entry => { Assert.Equal("testuser5", entry.Gamertag); Assert.Equal(9, entry.Rank); }
+                // TODO - The current implementation filters rows based on rank...
+                // Should we change it to be smarter and return consistent numbers of row regardless of duplicate scores?
+                //entry => { Assert.Equal("testuser4", entry.Gamertag); Assert.Equal(10, entry.Rank); },
+                //entry => { Assert.Equal("testuser3", entry.Gamertag); Assert.Equal(11, entry.Rank); }
+             );
             // update testuser make their score similar to mine and check they are around me
             await PostScoreAsync(client, 1050);
             response = await GetLeaderboardAsync(client, leaderboardName);
@@ -188,13 +207,15 @@ namespace Nether.Web.IntegrationTests.Leaderboard
 
             public class LeaderboardEntry
             {
+                public int Rank { get; set; }
+
                 public string Gamertag { get; set; }
 
                 public int Score { get; set; }
 
                 public override string ToString()
                 {
-                    return $"{Gamertag}\t {Score}";
+                    return $"{Rank}: {Gamertag}\t {Score}";
                 }
             }
         }


### PR DESCRIPTION
### Issue: 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Update stored procs for leaderboard to use RANK rather than ROW_NUMBER.

Before:

|gamertag|score|rank|
|---|----|---|
|player1|500|1
|player2|400|2
|player3|400|3
|player4|300|4
|player5|200|5

After:

|gamertag|score|rank|
|---|----|---|
|player1|500|1|
|player2|400|2|
|player3|400|2 **<-- Note change here**|
|player4|300|4|
|player5|200|5|


### Test:
Deploy SQL Schema
Build Nether.Web and run load tests (using both in-memory and SQL Store for Leaderboard)