### PR TITLE
Return 200 with null state if no player state set

### DIFF
--- a/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerController.cs
@@ -143,8 +143,6 @@ namespace Nether.Web.Features.PlayerManagement
 
             // Call data store
             var state = await _store.GetPlayerStateByGamertagAsync(gamertag);
-            if (state == null)
-                return NotFound();
 
             // Return result
             return Ok(new PlayerStateGetResponseModel { Gamertag = gamertag, State = state });


### PR DESCRIPTION
### Issue: 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Fix GET /player/state to return null state property when no state is set, rather than a 404

### Test:
* Build and run nether
* clear state. 
* Sign into Swagger UI as a player and issue GET /player/state
* Verify that you get a 200 OK response with

```json
{
 "gamertag": "yourtag",
 "state" : null
}
```
