### PR TITLE
Geoposition updates to Nether Analytics

### DIFF
--- a/src/Nether.Analytics.EventProcessor/GameEventData.cs
+++ b/src/Nether.Analytics.EventProcessor/GameEventData.cs
@@ -13,18 +13,17 @@ namespace Nether.Analytics.EventProcessor
 {
     public class GameEventData
     {
-        private string _data;
         private DateTime _enqueuedTime;
         private DateTime _dequeuedTime;
 
         public GameEventData(EventData eventData, DateTime dequeuedTime)
         {
-            _data = Encoding.UTF8.GetString(eventData.GetBytes());
+            Data = Encoding.UTF8.GetString(eventData.GetBytes());
             _enqueuedTime = eventData.EnqueuedTimeUtc;
             _dequeuedTime = dequeuedTime;
         }
 
-        public string Data => _data;
+        public string Data { get; set; }
         public DateTime EnqueuedTime => _enqueuedTime;
         public DateTime DequeuedTime => _dequeuedTime;
         public string EventType { get; set; } = "Unknown";
@@ -55,7 +54,7 @@ namespace Nether.Analytics.EventProcessor
 
             // All IGameEvents includes a properties-tag that should be automatically included in output as the last column
             var properties = json["properties"];
-            if (properties != null & properties.HasValues)
+            if (properties != null && properties.HasValues)
             {
                 var propDict = properties.ToObject<Dictionary<string, string>>();
                 var propertiesColumn = new StringBuilder();

--- a/src/Nether.Analytics.EventProcessor/Nether.Analytics.EventProcessor.csproj
+++ b/src/Nether.Analytics.EventProcessor/Nether.Analytics.EventProcessor.csproj
@@ -61,6 +61,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NGeoHash.Portable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NGeoHash.Portable.1.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\NGeoHash.Portable.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/Nether.Analytics.EventProcessor/Output/Blob/BlobOutputManager.cs
+++ b/src/Nether.Analytics.EventProcessor/Output/Blob/BlobOutputManager.cs
@@ -113,6 +113,12 @@ namespace Nether.Analytics.EventProcessor.Output.Blob
 
         private void AppendToFolder(string folder, params string[] lines)
         {
+            Console.WriteLine(folder);
+            foreach (var line in lines)
+            {
+                Console.WriteLine($"  {line}");
+            }
+
             var blob = GetTmpAppendBlob(folder);
 
             var data = string.Join("\n", lines) + "\n";

--- a/src/Nether.Analytics.EventProcessor/packages.config
+++ b/src/Nether.Analytics.EventProcessor/packages.config
@@ -12,6 +12,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.12" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="NGeoHash.Portable" version="1.0.0" targetFramework="net461" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net461" />
   <package id="WindowsAzure.ServiceBus" version="3.4.5" targetFramework="net461" />
   <package id="WindowsAzure.Storage" version="8.0.1" targetFramework="net461" />

--- a/src/Nether.Analytics.GameEvents/LocationEvent.cs
+++ b/src/Nether.Analytics.GameEvents/LocationEvent.cs
@@ -6,12 +6,21 @@ using System.Collections.Generic;
 
 namespace Nether.Analytics.GameEvents
 {
+    //TODO: Fix duplication of type LocationEvent, see below
+    // WARNING!!!
+    // THIS TYPE IS DUPLICATED AND EXISTS INSIDE FILE GameEventHandler.cs as well
+    // This is due to an issue where we are unable to reference to the GameEvents project
+    // from a native .NET Client (such as the GameEventsProcessor is)
+    // REMEMBER TO UPDATE THAT OTHER CLASS AS WELL IF YOU DO ANY UPDATES
     public class LocationEvent : IGameEvent
     {
         public string Type => "location";
         public string Version => "1.0.0";
         public DateTime ClientUtcTime { get; set; }
         public string GameSessionId { get; set; }
+        public double Longitude { get; set; }
+        public double Latitute { get; set; }
+        public string Geohash { get; set; }
         public Dictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/TestClients/AnalyticsMapTestClient/index.html
+++ b/src/TestClients/AnalyticsMapTestClient/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Analytics Map Test Client</title>
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.1.1.min.js"></script>
+    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?branch=experimental'></script>
+    <script type='text/javascript' src='netherClient.js'></script> 
+    <script type="text/javascript" src="index.js"></script>
+</head>
+
+<body onload='loadMapScenario();'>
+    <div id='myMap' style='width: 100vw; height: 100vh;'></div> 
+</body>
+
+</html>

--- a/src/TestClients/AnalyticsMapTestClient/index.js
+++ b/src/TestClients/AnalyticsMapTestClient/index.js
@@ -4,7 +4,7 @@ var netherClient;
 
 function loadMapScenario() {
     map = new Microsoft.Maps.Map(document.getElementById('myMap'), {
-        credentials: 'AkSg8WKvYlSfF0u9-CSclN2m-v1SU9WkI4iwV9szphXqU6htZpcN4JWY4-pEbjTr'
+        credentials: ''
     });
 
     Microsoft.Maps.Events.addHandler(map, 'click', mapClick);
@@ -13,9 +13,20 @@ function loadMapScenario() {
 
 function mapClick(e) {
 
-    console.log(e);
-    console.log('Longitude: ' + e.location.longitude);
-    console.log('Latitude:  ' + e.location.latitude);
+    console.log('Click recorded at:');
+    console.log('  Longitude: ' + e.location.longitude);
+    console.log('  Latitude : ' + e.location.latitude);
 
-    netherClient.sendEvent({"type":"location"});
+    netherClient.sendEvent(
+        {
+            "type": "location",
+            "version": "1.0.0",
+            "clientUtcTime": "2017-02-17 14:00:00",
+            "gameSessionId": "session1",
+            "longitude": e.location.longitude,
+            "latitude": e.location.latitude,
+            "geohash": ""
+        }, function(){
+            console.log("done!");
+        });
 }

--- a/src/TestClients/AnalyticsMapTestClient/index.js
+++ b/src/TestClients/AnalyticsMapTestClient/index.js
@@ -4,7 +4,7 @@ var netherClient;
 
 function loadMapScenario() {
     map = new Microsoft.Maps.Map(document.getElementById('myMap'), {
-        credentials: ''
+        credentials: 'PUT_YOUR_BING_MAPS_KEY_HERE'
     });
 
     Microsoft.Maps.Events.addHandler(map, 'click', mapClick);

--- a/src/TestClients/AnalyticsMapTestClient/index.js
+++ b/src/TestClients/AnalyticsMapTestClient/index.js
@@ -1,0 +1,21 @@
+var map;
+var endpointInfo;
+var netherClient;
+
+function loadMapScenario() {
+    map = new Microsoft.Maps.Map(document.getElementById('myMap'), {
+        credentials: 'AkSg8WKvYlSfF0u9-CSclN2m-v1SU9WkI4iwV9szphXqU6htZpcN4JWY4-pEbjTr'
+    });
+
+    Microsoft.Maps.Events.addHandler(map, 'click', mapClick);
+    netherClient = new NetherClient("http://localhost:5000");
+}
+
+function mapClick(e) {
+
+    console.log(e);
+    console.log('Longitude: ' + e.location.longitude);
+    console.log('Latitude:  ' + e.location.latitude);
+
+    netherClient.sendEvent({"type":"location"});
+}

--- a/src/TestClients/AnalyticsMapTestClient/netherClient.js
+++ b/src/TestClients/AnalyticsMapTestClient/netherClient.js
@@ -1,0 +1,62 @@
+function NetherClient(netherBaseUrl) {
+
+    this.netherBaseUrl = netherBaseUrl;
+
+    this.authorization = "";
+    this.contentType = "";
+    this.httpVerb = "";
+    this.url = "";
+    this.validUntil = new Date(-8640000000000000);
+
+    this.sendEvent = function (gameEvent, success) {
+        var self = this;
+        var now = new Date();
+
+        if (this.validUntil < now) {
+            this._updateEndpointInfo(function () {
+                self._sendToEventHub(gameEvent, success)
+            });
+        }
+        else {
+            self._sendToEventHub(gameEvent, success);
+        }
+    }
+
+    this._updateEndpointInfo = function (success) {
+        var self = this;
+
+        $.getJSON(this.netherBaseUrl + "/api/endpoint", function (info) {
+            console.log('Nether Analytics Endpoint Information Recieved and Updated');
+            console.log(info);
+
+            self.authorization = info.authorization;
+            self.contentType = info.contentType;
+            self.httpVerb = info.httpVerb;
+            self.url = info.url;
+            self.validUntil = new Date(info.validUntilUtc);
+
+            success();
+        });
+    }
+
+    this._sendToEventHub = function (gameEvent, success) {
+        var self = this;
+
+        var json = JSON.stringify(gameEvent);
+        console.log('Sending event:');
+        console.log(json);
+
+        $.ajax({
+            type: self.httpVerb,
+            url: self.url,
+            data: json,
+            dataType: self.contentType,
+
+            beforeSend: function (request) {
+                request.setRequestHeader("ContentType", self.contentType);
+                request.setRequestHeader("Authorization", self.authorization);
+            },
+            success: dataSentToEventHub
+        });
+    }
+}

--- a/src/TestClients/AnalyticsMapTestClient/netherClient.js
+++ b/src/TestClients/AnalyticsMapTestClient/netherClient.js
@@ -8,7 +8,7 @@ function NetherClient(netherBaseUrl) {
     this.url = "";
     this.validUntil = new Date(-8640000000000000);
 
-    this.sendEvent = function (gameEvent, success) {
+    this.sendEvent = function (gameEvent, success = null) {
         var self = this;
         var now = new Date();
 
@@ -56,7 +56,10 @@ function NetherClient(netherBaseUrl) {
                 request.setRequestHeader("ContentType", self.contentType);
                 request.setRequestHeader("Authorization", self.authorization);
             },
-            success: dataSentToEventHub
+            success: function () {
+                if (success != null)
+                    success();
+            }
         });
     }
 }


### PR DESCRIPTION
### Issue: #340 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:

* Game processor has been updated to handle location events containing geo-positions (longitude and latitude) and calculate geohashes of those unless provided by the client.
* A new test client has been created to make testing of sending "Location Events" easy. It's a static website that uses Bing Maps to show a map and accept inputs by clicking in on the map.

### Test:
Start multiple projects:

* Nether.Web
* Nether.Analytics.EventProcessor

Launch your favorite browser, locate and open:
[NetherRootFolder]\srs\TestClients\AnalyticsMapTestClient\index.html
(this is easily done by clicking on this file in Windows Explorer or similar tool on other operating systems)

The web site might show an error message telling that the license key for Bing Maps is invalid. If you want to get rid of that error, go to https://www.bingmapsportal.com and sign up for your own key, copy and paste the key in the file index.js. YOU DON'T NEED A VALID KEY to test this functionality since the Bing Maps control will still be responsive even if the error message are shown in the middle.

Press F12 in your browser to show Developer Tools and look at the JavaScript Console.

Now click on the map and watch how events are sent to Nether by:
* First connecting to the Nether API, to get a valid key
* Caches the key and other connection information
* Send location events directly to Event Hub using the secured connection

Meanwhile, the Event Processor should pick up the new events and position the information within the events on Blob Storage as usual. One noteworthy piece of information is that the EventProcessor will encode the Longitude and Latitudes into a GeoHash that gets added to the resulting rows.