### PR TITLE
Enable Development mode exception info

### DIFF
--- a/src/Nether.Web/Utilities/ErrorModel.cs
+++ b/src/Nether.Web/Utilities/ErrorModel.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nether.Web.Utilities
+{
+    // minimal error model inpsired by https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md#7102-error-condition-responses
+
+    public class ErrorModel
+    {
+        [JsonProperty]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ErrorCode Code { get; set; }
+
+        public string Message { get; set; }
+    }
+
+    public enum ErrorCode
+    {
+        UnhandledException
+    }
+}

--- a/src/Nether.Web/Utilities/ExceptionLoggingFilterAttribute.cs
+++ b/src/Nether.Web/Utilities/ExceptionLoggingFilterAttribute.cs
@@ -1,27 +1,56 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Nether.Web.Utilities
 {
     public class ExceptionLoggingFilterAttribute : ExceptionFilterAttribute
     {
-        private readonly ILogger<ExceptionLoggingFilterAttribute> _logger;
+        private readonly ILogger _logger;
+        private readonly IHostingEnvironment _hostingEnvironment;
 
-        public ExceptionLoggingFilterAttribute(ILogger<ExceptionLoggingFilterAttribute> logger)
+        public ExceptionLoggingFilterAttribute(
+            ILogger<ExceptionLoggingFilterAttribute> logger,
+            IHostingEnvironment hostingEnvironment
+            )
         {
+            _hostingEnvironment = hostingEnvironment;
             _logger = logger;
         }
         public override void OnException(ExceptionContext context)
         {
-            _logger.LogError(context.Exception.ToString());
+            string message;
+            if (_hostingEnvironment.EnvironmentName == "Development")
+            {
+                // For development, write full exception message to client
+                _logger.LogError("Unhandled exception: {0}", context.Exception);
+                message = context.Exception.ToString();
+            }
+            else
+            {
+                // For non-development, write full exception message to log with identifier
+                // and write identifier to client
+                var id = Guid.NewGuid().ToString();
+                _logger.LogError("Unhandled exception (error-id = {0}): {1}", id, context.Exception);
+                message = $"Unhandled exception. Check logs for error id '{id}'";
+            }
+
+            var error = new ErrorModel
+            {
+                Code = ErrorCode.UnhandledException,
+                Message = message
+            };
+            context.Result = new ObjectResult(error) { StatusCode = (int)HttpStatusCode.InternalServerError };
         }
     }
 }

--- a/tests/Nether.Web.IntegrationTests/HttpResponseMessageAssertions.cs
+++ b/tests/Nether.Web.IntegrationTests/HttpResponseMessageAssertions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Nether.Web.IntegrationTests
+{
+    public static class HttpResponseMessageAssertions
+    {
+        public static async Task AssertSuccessStatusCodeAsync(this HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await GetBodyContentAsync(response);
+                throw new XunitException($"NonSuccessStatusCode. Body: {body}");
+            }
+        }
+        public static async Task AssertStatusCodeAsync(this HttpResponseMessage response, HttpStatusCode expectedStatusCode)
+        {
+            if (response.StatusCode != expectedStatusCode)
+            {
+                string body = await GetBodyContentAsync(response);
+                throw new XunitException($"Expected status code: {expectedStatusCode}, actual {response.StatusCode}. Body: {body}");
+            }
+        }
+
+        private static async Task<string> GetBodyContentAsync(HttpResponseMessage response)
+        {
+            string body = null;
+            try
+            {
+                body = await response.Content.ReadAsStringAsync();
+            }
+            catch (Exception)
+            { }
+
+            return body;
+        }
+    }
+}

--- a/tests/Nether.Web.IntegrationTests/Identity/LoginApiTests.cs
+++ b/tests/Nether.Web.IntegrationTests/Identity/LoginApiTests.cs
@@ -19,7 +19,7 @@ namespace Nether.Web.IntegrationTests.Identity
         {
             var client = await AsAdminAsync();
 
-            // create user 
+            // create user
             var response = await client.PostAsJsonAsync(
                 "/api/identity/users",
                 new
@@ -42,7 +42,7 @@ namespace Nether.Web.IntegrationTests.Identity
                     password
                 });
 
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.Created);
 
             var loginLocation = response.Headers.Location.LocalPath;
             Assert.NotNull(loginLocation);
@@ -50,7 +50,7 @@ namespace Nether.Web.IntegrationTests.Identity
             // Get the user again and verify the login is present in the returned data
             response = await client.GetAsync(userLocation);
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             var userContent = await response.Content.ReadAsAsync<dynamic>();
             var user = userContent.user;
             var logins = ((JArray)user.logins).Cast<dynamic>().ToList();
@@ -67,7 +67,7 @@ namespace Nether.Web.IntegrationTests.Identity
 
             // delete the user
             response = await client.DeleteAsync(userLocation);
-            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.NoContent);
         }
 
 

--- a/tests/Nether.Web.IntegrationTests/Identity/SignInTests.cs
+++ b/tests/Nether.Web.IntegrationTests/Identity/SignInTests.cs
@@ -50,7 +50,7 @@ namespace Nether.Web.IntegrationTests.Identity
             // PUT /api/players
             var player = new { gamertag = "testuser-notag", country = "UK", customTag = "IntegrationTestUser" };
             playerResponse = await client.PutAsJsonAsync("api/player", player);
-            playerResponse.EnsureSuccessStatusCode();
+            await playerResponse.AssertSuccessStatusCodeAsync();
 
             // Reauthenticate
             accessTokenResult = await GetAccessToken(client, username, password);
@@ -71,14 +71,14 @@ namespace Nether.Web.IntegrationTests.Identity
 
             // GET /api/player
             playerResponse = await client.GetAsync("api/player");
-            playerResponse.EnsureSuccessStatusCode();
+            await playerResponse.AssertSuccessStatusCodeAsync();
 
             // GET /api/player
             var playerGroupsResponse = await client.GetAsync("api/player/groups");
 
             // DELETE /api/player
             playerResponse = await client.DeleteAsync("api/player");
-            playerResponse.EnsureSuccessStatusCode();
+            await playerResponse.AssertSuccessStatusCodeAsync();
         }
 
 

--- a/tests/Nether.Web.IntegrationTests/Identity/UserApiTests.cs
+++ b/tests/Nether.Web.IntegrationTests/Identity/UserApiTests.cs
@@ -19,14 +19,14 @@ namespace Nether.Web.IntegrationTests.Identity
             var client = await AsPlayerAsync();
 
             var response = await client.GetAsync("/api/identity/users");
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.Forbidden);
         }
         [Fact]
         public async Task As_a_player_I_get_Forbidden_response_calling_GetUser()
         {
             var client = await AsPlayerAsync();
             var response = await client.GetAsync("/api/identity/users/123");
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.Forbidden);
         }
         // ... should we fill out the other requests to check permissions, or not?
 
@@ -36,7 +36,7 @@ namespace Nether.Web.IntegrationTests.Identity
         {
             var client = await AsAdminAsync();
             var response = await client.GetAsync("/api/identity/users");
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
 
             dynamic responseContent = await response.Content.ReadAsAsync<dynamic>();
             var users = ((IEnumerable<dynamic>)responseContent.users).ToList();
@@ -69,7 +69,7 @@ namespace Nether.Web.IntegrationTests.Identity
                     active = true
                 });
 
-            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.Created);
 
             var userLocation = response.Headers.Location.LocalPath;
             Assert.StartsWith("/api/identity/users/", userLocation);
@@ -78,7 +78,7 @@ namespace Nether.Web.IntegrationTests.Identity
             // Get user
             response = await client.GetAsync(userLocation);
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             dynamic userContent = await response.Content.ReadAsAsync<dynamic>();
             dynamic user = userContent.user;
 
@@ -97,7 +97,7 @@ namespace Nether.Web.IntegrationTests.Identity
                     active = false
                 });
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             userContent = await response.Content.ReadAsAsync<dynamic>();
             user = userContent.user;
             Assert.Equal(userId, (string)user.userId);
@@ -108,7 +108,7 @@ namespace Nether.Web.IntegrationTests.Identity
             // Get user again
             response = await client.GetAsync(userLocation);
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
             userContent = await response.Content.ReadAsAsync<dynamic>();
             user = userContent.user;
             Assert.Equal(userId, (string)user.userId);
@@ -118,12 +118,12 @@ namespace Nether.Web.IntegrationTests.Identity
 
             // Remove user
             response = await client.DeleteAsync(userLocation);
-            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.NoContent);
 
 
             // Get user again (shouldn't exist)
             response = await client.GetAsync(userLocation);
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.NotFound);
         }
 
         private async Task<HttpClient> AsPlayerAsync()

--- a/tests/Nether.Web.IntegrationTests/IntegrationTestUsersFixture.cs
+++ b/tests/Nether.Web.IntegrationTests/IntegrationTestUsersFixture.cs
@@ -60,7 +60,7 @@ namespace Nether.Web.IntegrationTests
                     role = role,
                     active = true
                 });
-            response.EnsureSuccessStatusCode();
+            await response.AssertSuccessStatusCodeAsync();
             var responseContent = await response.Content.ReadAsAsync<dynamic>();
             _createdUserNames.Add(username);
 
@@ -71,7 +71,7 @@ namespace Nether.Web.IntegrationTests
                 {
                     password
                 });
-            response.EnsureSuccessStatusCode();
+            await response.AssertSuccessStatusCodeAsync();
 
             if (!string.IsNullOrEmpty(gamertag))
             {
@@ -84,7 +84,7 @@ namespace Nether.Web.IntegrationTests
                     customTag = "IntegrationTestUser"
                 };
                 response = await playerClient.PutAsJsonAsync("api/player", player);
-                response.EnsureSuccessStatusCode();
+                await response.AssertSuccessStatusCodeAsync();
 
                 _createdPlayers.Add(gamertag);
             }

--- a/tests/Nether.Web.IntegrationTests/Leaderboard/LeaderboardTests.cs
+++ b/tests/Nether.Web.IntegrationTests/Leaderboard/LeaderboardTests.cs
@@ -27,7 +27,7 @@ namespace Nether.Web.IntegrationTests.Leaderboard
         {
             var client = await GetClientAsync();
             HttpResponseMessage response = await client.GetAsync(LeaderboardBasePath + "/Default");
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Nether.Web.IntegrationTests.Leaderboard
         private async Task DeleteMyScoresAsync(HttpClient client)
         {
             var response = await client.DeleteAsync(ScoresBasePath);
-            response.EnsureSuccessStatusCode();
+            await response.AssertSuccessStatusCodeAsync();
         }
 
         private async Task<LeaderboardGetResponse> GetLeaderboardAsync(
@@ -176,7 +176,7 @@ namespace Nether.Web.IntegrationTests.Leaderboard
             HttpStatusCode expectedCode = HttpStatusCode.OK)
         {
             HttpResponseMessage response = await client.GetAsync(LeaderboardBasePath + "/" + type);
-            Assert.Equal(expectedCode, response.StatusCode);
+            await response.AssertStatusCodeAsync(expectedCode);
 
             string content = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<LeaderboardGetResponse>(content);
@@ -194,7 +194,7 @@ namespace Nether.Web.IntegrationTests.Leaderboard
                     score = score
                 });
 
-            Assert.Equal(expectedCode, response.StatusCode);
+            await response.AssertStatusCodeAsync(expectedCode);
         }
 
         #endregion

--- a/tests/Nether.Web.IntegrationTests/PlayerManagement/PlayerManagementTests.cs
+++ b/tests/Nether.Web.IntegrationTests/PlayerManagement/PlayerManagementTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Newtonsoft.Json;

--- a/tests/Nether.Web.IntegrationTests/SwaggerTests.cs
+++ b/tests/Nether.Web.IntegrationTests/SwaggerTests.cs
@@ -20,7 +20,7 @@ namespace Nether.Web.IntegrationTests
 
             var response = await client.GetAsync($"{WebTestBase.BaseUrl}api/swagger/v0.1/swagger.json");
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
         }
     }
 }


### PR DESCRIPTION
### Issue:

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
* Update the exception handling filter to check whether the app is in Development mode and output exception messages in 500 Responses in this scenario.
* For environments not configured as Development, output an error id that can be correlated with the logs
* Update assertions in integration tests to output the HTTP response body when the status code doesn't match the expected code

### Test:
* Build and Run Nether.Web. 
* Force an exception, e.g. by setting an invalid connection string for Leaderboard and using swagger ui to retrieve leaderboard.
* With ASPNETCORE_ENVIRONMENT set to Development you should see the exception message in the HTTP response.
* With ASPNETCORE_ENVIRONMENT set to anything else you should get an id in the message that is also output to the logs. NOTE: You will need to comment out [this line](https://github.com/MicrosoftDX/nether/blob/f0bde56bc58d449b227cfeb7a008974a5116ea38/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs#L142) to enable non-Development mode! 
* Repeat the above conditions and run the integration tests. When set to Development, the test failure should include the error message in Test Explorer. When no set to Development you shouldn't see the server exception.