### PR TITLE
Fb token fix

### DIFF
--- a/src/Nether.Data/Identity/LoginProvider.cs
+++ b/src/Nether.Data/Identity/LoginProvider.cs
@@ -11,6 +11,6 @@ namespace Nether.Data.Identity
     public static class LoginProvider
     {
         public const string UserNamePassword = "password";
-        public const string FacebookUserAccessToken = "facebook-user-access-token";
+        public const string FacebookUserAccessToken = "Facebook"; // use the same identifier as the implicit flow for facebook
     }
 }

--- a/src/TestClients/FacebookUserTokenClient/Program.cs
+++ b/src/TestClients/FacebookUserTokenClient/Program.cs
@@ -82,7 +82,7 @@ namespace FacebookUserTokenClient
 
         public static async Task PostScoreAsync(this HttpClient client, string bearerToken, int score)
         {
-            var response = await client.PostAsJsonAsync("/api/leaderboard", new { country = "missing", customTag = "testclient", score = score });
+            var response = await client.PostAsJsonAsync("/api/scores", new { country = "missing", customTag = "testclient", score = score });
 
             response.EnsureSuccessStatusCode();
         }

--- a/src/TestClients/IdentityServerTestClient/Program.cs
+++ b/src/TestClients/IdentityServerTestClient/Program.cs
@@ -214,7 +214,7 @@ namespace IdentityServerTestClient
         {
             var client = new HttpClient();
             client.SetBearerToken(accessToken);
-            var response = await client.PostAsJsonAsync("http://localhost:5000/api/leaderboard", new { country = "missing", score = score });
+            var response = await client.PostAsJsonAsync("http://localhost:5000/api/scores", new { country = "missing", score = score });
 
             response.EnsureSuccessStatusCode();
         }


### PR DESCRIPTION
### Issue: #353

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Briefly describe the work that has been done and how that differ from what was there before. Only a few sentences since reviewer should be able to find more information in the issue linked at the top.

### Test:
Configure facebook and facebookuseraccesstoken sign in as per [docs](https://github.com/MicrosoftDX/nether/blob/master/documentation/identity/configuration.md#signin-methods)
Build and run Nether.Web
Run src/TestClients/FacebookUserTokenClient using the user token for your facebook app from https://developers.facebook.com/tools/accesstoken. Create a gamertag if prompted
Run swagger ui and sign in using facebook, and check that the identity-test API returns your gamertag as set above
