### PR TITLE
fixed compiled ui ts output

### DIFF
--- a/src/Nether.Web/gulpfile.js
+++ b/src/Nether.Web/gulpfile.js
@@ -13,9 +13,10 @@ gulp.task('default', function () {
 
 // compiles ts files in js and outputs them in the same folder
 gulp.task("compiletsforadminui", function () {
-    return tsProject.src()
-        .pipe(tsProject())
-        .js.pipe(gulp.dest("."));
+    console.log('compile ts ui files into js');
+    var tsResult = gulp.src(["./wwwroot/**/*.ts"], {base: "."}) 
+        .pipe(tsProject()); 
+    return tsResult.js.pipe(gulp.dest('.'));
 });
 
 gulp.task("npmtolib", () => {


### PR DESCRIPTION
### Issue: #350 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
When running build.ps1 the output js files would end up in the wrong folder.
The issue was related to a wrong build pipeline in the gulpfile.js

### Test:
Run build.ps1 or Build.sh and verify that the compiled .js files are generated in the same folders as the .ts files under wwwroot

(Make sure that all above information is provided before submitting your pull request)
