### PR TITLE
Package up Nether.Web.zip in appveyor build

### DIFF
--- a/appveyor-packageweb.ps1
+++ b/appveyor-packageweb.ps1
@@ -1,0 +1,5 @@
+$netherRoot = $PSScriptRoot
+
+dotnet publish "$netherRoot/src/Nether.Web" -c Release
+[Reflection.Assembly]::LoadWithPartialName( "System.IO.Compression.FileSystem" ) | out-null
+[System.IO.Compression.ZipFile]::CreateFromDirectory("$netherRoot/src/Nether.Web/bin/Release/netcoreapp1.1/publish", "$netherRoot/src/Nether.Web/bin/Release/netcoreapp1.1/Nether.Web.zip", "Fastest", $false)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,8 @@ build_script:
 - gulp --version
 - ps: ./RunCodeFormatter.ps1
 - ps: ./build.ps1
+- ps: ./appveyor-packageweb.ps1
+after_build:
+- ps:  Push-AppveyorArtifact src/Nether.Web/bin/Release/netcoreapp1.1/Nether.Web.zip -FileName Nether.Web.Zip -Type WebDeployPackage
 test_script:
 - ps: ./run-unit-tests.ps1


### PR DESCRIPTION
### Issue: #290 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Add script to appveyor build to run `dotnet publish` on Nether.Web and package as Nether.Web.zip artifact in appveyor build

### Test:
Check the appveyor build has the zip file as an artifact