### PR TITLE
Add quickstart deployment template and deploy to azure button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Travis:   [![Build Status](https://travis-ci.org/MicrosoftDX/nether.svg?branch=m
 -->
 
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftDX%2Fnether%2Fmaster%2Fdeployment%2Fnether-deploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftDX%2Fnether%2Fmaster%2Fdeployment%2Fnether-deploy-quickstart.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
 
 
 ## About

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Travis:   [![Build Status](https://travis-ci.org/MicrosoftDX/nether.svg?branch=m
 -->
 
 
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftDX%2Fnether%2Fmaster%2Fdeployment%2Fnether-deploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
+
 
 ## About
 

--- a/appveyor-packageweb.ps1
+++ b/appveyor-packageweb.ps1
@@ -1,5 +1,7 @@
 $netherRoot = $PSScriptRoot
 
 dotnet publish "$netherRoot/src/Nether.Web" -c Release
+Copy-Item "$publishPath/../Nether.Web.xml" $publishPath
+
 [Reflection.Assembly]::LoadWithPartialName( "System.IO.Compression.FileSystem" ) | out-null
 [System.IO.Compression.ZipFile]::CreateFromDirectory("$netherRoot/src/Nether.Web/bin/Release/netcoreapp1.1/publish", "$netherRoot/src/Nether.Web/bin/Release/netcoreapp1.1/Nether.Web.zip", "Fastest", $false)

--- a/deployment/deploy.ps1
+++ b/deployment/deploy.ps1
@@ -18,6 +18,10 @@ param
     $NetherWebDomainPrefix,
 
     [Parameter(Mandatory=$true)]
+    [securestring]
+    $initialNetherAdministratorPassword,
+
+    [Parameter(Mandatory=$true)]
     [string]
     $sqlServerName,
 
@@ -132,6 +136,7 @@ Get-ChildItem -File $netherRoot/deployment/* -Exclude *params.json -filter nethe
 
 $templateParameters = @{
     NetherWebDomainPrefix = $NetherWebDomainPrefix
+    initialNetherAdministratorPassword = $initialNetherAdministratorPassword
     sqlServerName = $sqlServerName
     sqlAdministratorLogin = $sqlAdministratorLogin
     sqlAdministratorPassword = $SqlAdministratorPassword

--- a/deployment/nether-deploy-eventhub.json
+++ b/deployment/nether-deploy-eventhub.json
@@ -10,7 +10,7 @@
         "ServiceBusNamespace": {
             "type": "string",
             "minLength": 3,
-            "maxLength": 15,
+            "maxLength": 30,
             "metadata": {
                 "description": "The unique storage account for use by Nether. only allows alpha characters and '-'. Cannot start or end with '-'."
             }

--- a/deployment/nether-deploy-quickstart.json
+++ b/deployment/nether-deploy-quickstart.json
@@ -27,7 +27,7 @@
     },
     "variables": {
         "deploymentAPI": "2015-01-01",
-        "suffix": "[uniqueString(subscription(), resourceGroup())]",
+        "suffix": "[uniqueString(subscription().subscriptionId, resourceGroup().id)]",
         "netherTemplateURI": "[uri(parameters('templateBaseURL'), 'nether-deploy.json')]",
         "NetherWebDomainPrefix" : "[concat('netherweb', variables('suffix'))]",
         "sqlServerName" : "[concat('nethersql', variables('suffix'))]",

--- a/deployment/nether-deploy-quickstart.json
+++ b/deployment/nether-deploy-quickstart.json
@@ -1,0 +1,93 @@
+{
+    /*
+    * This is the "master" template used to provision the Azure resources for Nether.
+    *
+    * This leverages linked templates which requires that the templates it links to are available via a URL. By default, these 
+    * will be pulled from the same location as this template. But this can be overridden by specifying a location via the pull 
+    * them from by specifying the templateBaseURL parameter.
+    * 
+    * For more information, please refer to the Nether repository at: https://github.com/MicrosoftDX/nether/tree/master/deployment
+    */
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "initialNetherAdministratorPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The initial password for the netheradmin user, sql server user, ..."
+            }
+        },
+        "templateBaseURL": {
+            "type": "string",
+            "defaultValue": "https://raw.githubusercontent.com/MicrosoftDX/nether/master/deployment/",
+            "metadata": {
+                "description": "The base location for all linked templates"
+            }
+        }
+    },
+    "variables": {
+        "deploymentAPI": "2015-01-01",
+        "suffix": "[uniqueString(subscription(), resourceGroup())]",
+        "netherTemplateURI": "[uri(parameters('templateBaseURL'), 'nether-deploy.json')]",
+        "NetherWebDomainPrefix" : "[concat('netherweb', variables('suffix'))]",
+        "sqlServerName" : "[concat('nethersql', variables('suffix'))]",
+        "sqlAdministratorLogin" : "nether",
+        "sqlAdministratorPassword" : "[parameters('initialNetherAdministratorPassword')]",
+        "analyticsEventHubNamespace": "[concat('nether', variables('suffix'))]",
+        "analyticsStorageAccountName": "[concat('nether', variables('suffix'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "NetherDeployment",
+            "apiVersion": "[variables('deploymentAPI')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('netherTemplateURI')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "NetherWebDomainPrefix": {
+                        "value": "[variables('NetherWebDomainPrefix')]"
+                    },
+                    "initialNetherAdministratorPassword": {
+                        "value": "[parameters('initialNetherAdministratorPassword')]"
+                    },
+                    "sqlServerName": {
+                        "value": "[variables('sqlServerName')]"
+                    },
+                    "sqlAdministratorLogin": {
+                        "value": "[variables('sqlAdministratorLogin')]"
+                    },
+                    "sqlAdministratorPassword": {
+                        "value": "[variables('sqlAdministratorPassword')]"
+                    },
+                    "analyticsEventHubNamespace": {
+                        "value": "[variables('analyticsEventHubNamespace')]"
+                    },
+                    "analyticsStorageAccountName": {
+                        "value": "[variables('analyticsStorageAccountName')]"
+                    },
+                    "templateBaseURL": {
+                        "value": "[parameters('templateBaseURL')]"
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "WebSiteFQDN": {
+            "type": "string",
+            "value": "[reference('WebTemplate').Outputs.webSiteFQDN.value]"
+        },
+        "DatabaseServerFQDN": {
+            "type": "string",
+            "value": "[reference('SQLDatabaseTemplate').Outputs.databaseServerFQDN.value]"
+        },
+        "DatabaseName": {
+            "type": "string",
+            "value": "[reference('SQLDatabaseTemplate').Outputs.databaseName.value]"
+        }
+    }
+}

--- a/deployment/nether-deploy-quickstart.json
+++ b/deployment/nether-deploy-quickstart.json
@@ -31,7 +31,7 @@
         "netherTemplateURI": "[uri(parameters('templateBaseURL'), 'nether-deploy.json')]",
         "NetherWebDomainPrefix" : "[concat('netherweb', variables('suffix'))]",
         "sqlServerName" : "[concat('nethersql', variables('suffix'))]",
-        "sqlAdministratorLogin" : "nether",
+        "sqlAdministratorLogin" : "nethersqladmin",
         "sqlAdministratorPassword" : "[parameters('initialNetherAdministratorPassword')]",
         "analyticsEventHubNamespace": "[concat('nether', variables('suffix'))]",
         "analyticsStorageAccountName": "[concat('nether', variables('suffix'))]"
@@ -79,15 +79,15 @@
     "outputs": {
         "WebSiteFQDN": {
             "type": "string",
-            "value": "[reference('WebTemplate').Outputs.webSiteFQDN.value]"
+            "value": "[reference('NetherDeployment').Outputs.WebSiteFQDN.value]"
         },
         "DatabaseServerFQDN": {
             "type": "string",
-            "value": "[reference('SQLDatabaseTemplate').Outputs.databaseServerFQDN.value]"
+            "value": "[reference('NetherDeployment').Outputs.DatabaseServerFQDN.value]"
         },
         "DatabaseName": {
             "type": "string",
-            "value": "[reference('SQLDatabaseTemplate').Outputs.databaseName.value]"
+            "value": "[reference('NetherDeployment').Outputs.DatabaseName.value]"
         }
     }
 }

--- a/deployment/nether-deploy-storageAccount.json
+++ b/deployment/nether-deploy-storageAccount.json
@@ -10,7 +10,7 @@
         "storageAccountName": {
             "type": "string",
             "minLength": 3,
-            "maxLength": 15,
+            "maxLength": 24,
             "metadata": {
                 "description": "The unique storage account for use by Nether. only allows alpha characters and '-'. Cannot start or end with '-'."
             }

--- a/deployment/nether-deploy-web.json
+++ b/deployment/nether-deploy-web.json
@@ -10,7 +10,7 @@
         "NetherWebDomainPrefix": {
             "type": "string",
             "minLength": 6,
-            "maxLength": 12,
+            "maxLength": 22,
             "metadata": {
                 "description": "The begining portion of the Nether web deployment URL (must be globally unique). only allows alpha characters and '-'. Cannot start or end with '-'."
             }

--- a/deployment/nether-deploy-web.json
+++ b/deployment/nether-deploy-web.json
@@ -66,6 +66,12 @@
                 "description": "The password of the admin user of the SQL Server"
             }
         },
+        "initialNetherAdministratorPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The initial password for the netheradmin user"
+            }
+        },
         "eventhubSendPolicy": {
             "type": "object",
             "metadata": {
@@ -82,7 +88,7 @@
     "variables": {
         "WebResourceAPI": "2015-08-01",
         "hostingPlanName": "[toLower(concat(parameters('NetherWebDomainPrefix'), '-hostingplan'))]",
-        "webSiteName": "[toLower(concat(parameters('NetherWebDomainPrefix'), '-website'))]",
+        "webSiteName": "[toLower(concat(parameters('NetherWebDomainPrefix')))]",
         /* The webHostingPlan specified in the input parameter is translated into the app host plan settings via this array */
         "HostingSKUs" : {
             "Free (no 'always on')" : {
@@ -241,6 +247,9 @@
                     "Analytics:EventHub:AccessKey": "[parameters('eventhubSendPolicy').policyKey]",
                     "Analytics:Store:wellknown": "sql",
                     "Analytics:Store:properties:ConnectionString": "[variables('sqlConnString')]",
+
+                    /* TODO: Add explanation of section */
+                    "Identity:InitialSetup:AdminPassword": "[parameters('initialNetherAdministratorPassword')]",
 
                     /* TODO: Add explanation of section */
                     "Identity:Store:wellknown": "sql",

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -53,6 +53,12 @@
                 "description": "(Optional) Absolute URI containing the Nether API's deployment package (ZIP). If not included, you'll need to deploy the package seperately."
             }
         },
+        "initialNetherAdministratorPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The initial password for the netheradmin user"
+            }
+        },
         "sqlServerName": {
             "type": "string",
             "minLength": 8,
@@ -265,7 +271,8 @@
                     "sqlAdministratorLogin": { "value": "[parameters('sqlAdministratorLogin')]" },
                     "sqlAdministratorPassword": { "value": "[parameters('sqlAdministratorPassword')]" },
                     "eventhubSendPolicy": { "value": "[reference('EventHubTemplate').outputs.sendPolicy.value]" },
-                    "webZipUri": { "value": "[parameters('webZipUri')]" }
+                    "webZipUri": { "value": "[parameters('webZipUri')]" },
+                    "initialNetherAdministratorPassword": { "value": "[parameters('initialNetherAdministratorPassword')]"}
                 } 
             } 
         },

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -14,7 +14,7 @@
         "NetherWebDomainPrefix": {
             "type": "string",
             "minLength": 6,
-            "maxLength": 12,
+            "maxLength": 22,
             "metadata": {
                 "description": "The begining portion of the Nether web deployment URL (must be globally unique). only allows alpha characters and '-'. Cannot start or end with '-'." 
             }
@@ -103,7 +103,7 @@
         "analyticsEventHubNamespace": {
             "type": "string",
             "minLength": 3,
-            "maxLength": 15,
+            "maxLength": 30,
             "metadata": {
                 "description": "The unique storage account for use by Nether. only allows alpha characters and '-'. Cannot start or end with '-'."
             }
@@ -166,7 +166,7 @@
         "analyticsStorageAccountName": {
             "type": "string",
             "minLength": 3,
-            "maxLength": 15,
+            "maxLength": 24,
             "metadata": {
                 "description": "The unique storage account for use by Nether. only allows alpha characters and '-'. Cannot start or end with '-'."
             }

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -180,7 +180,7 @@
         },
         "templateBaseURL": {
             "type": "string",
-            "defaultValue": "[deployment().properties.templateLink.uri]",
+            "defaultValue": "https://raw.githubusercontent.com/MicrosoftDX/nether/master/deployment/",
             "metadata": {
                 "description": "The base location for all linked templates."
             }   

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -48,6 +48,7 @@
         },
         "webZipUri": {
             "type": "string",
+            "defaultValue": "https://netherartifacts.blob.core.windows.net/deployment-artifacts/master/Nether.Web.Zip",
             "metadata": {
                 "description": "(Optional) Absolute URI containing the Nether API's deployment package (ZIP). If not included, you'll need to deploy the package seperately."
             }

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -1,13 +1,13 @@
-/*
-* This is the "master" template used to provision the Azure resources for Nether.
-*
-* This leverages linked templates which requires that the templates it links to are available via a URL. By default, these 
-* will be pulled from the same location as this template. But this can be overridden by specifying a location via the pull 
-* them from by specifying the templateBaseURL parameter.
-* 
-* For more information, please refer to the Nether repository at: https://github.com/MicrosoftDX/nether/tree/master/deployment
-*/
 {
+    /*
+    * This is the "master" template used to provision the Azure resources for Nether.
+    *
+    * This leverages linked templates which requires that the templates it links to are available via a URL. By default, these 
+    * will be pulled from the same location as this template. But this can be overridden by specifying a location via the pull 
+    * them from by specifying the templateBaseURL parameter.
+    * 
+    * For more information, please refer to the Nether repository at: https://github.com/MicrosoftDX/nether/tree/master/deployment
+    */
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": { 

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -36,7 +36,7 @@
                 "Premium P3"
             ], 
             "metadata": { 
-                "description": "Specifies the database pricing/performance." 
+                "description": "Specifies the App Service pricing/performance." 
             } 
         }, 
         "InstanceCount": {


### PR DESCRIPTION
### Issue: #290

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
* Add a new nether-deploy-quickstart.json template file designed for getting up and running quickly with Nether.Web to evaluate. This aims to minimise the number of parameters the user is prompted for, e.g. defaulting to free web app tier, basic sqldb. Additionally, it fixes the sql user name as `nether` and reuses the password the user enters for the netheradmin user for the login to the created database
* Fixes the zip creation in appveyor to include the Nether.Web.Xml file used by swagger ui
* Add parameter to allow the user to enter the initial adminstrator password (rather than using a fixed password)
* Add a Deploy to Azure button to the readme. This button uses the nether-deploy-quickstart.json template

### Test:
Since the Deploy to Azure button needs the link to the template, the PR has the link to the template that will exist _after_ the PR has been merged.

So, for testing use this link which points to the files in the branch used for the PR: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fstuartleeks%2Fnether%2Fdeploy-to-azure%2Fdeployment%2Fnether-deploy-quickstart.json

You will also need to override the template base url parameter to pick up the changes to the templates using https://raw.githubusercontent.com/stuartleeks/nether/deploy-to-azure/deployment/

Unfortunately, you won't be able to log in as the fix to include the Nether.Web.xml in the appveyor package is in this PR!