### PR TITLE
Add Appveyor integration tests (in-memory stores)

### DIFF
--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -25,3 +25,8 @@ if (-not $loaded){
 }
 
 &"$netherRoot\run-integration-tests.ps1"
+if ($LASTEXITCODE -ne 0){
+    $testExitCode = $LASTEXITCODE
+    Write-Host "Integration tests failed: $testExitCode"
+    exit $testExitCode
+}

--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -1,0 +1,27 @@
+$netherRoot = $PSScriptRoot
+
+# launch Nether.Web
+Start-Process powershell "$netherRoot\rundev.ps1"
+
+# test for 200 OK from GET http://localhost:5000
+# with a retry window of 300 seconds 
+$maximumRetryInSeconds = 300
+$startTime = Get-Date
+$r = $null
+$loaded = $false
+while (((Get-Date) - $startTime).TotalSeconds -le $maximumRetryInSeconds) {
+  Write-Host "testing http://localhost:5000"
+  try { $r = Invoke-WebRequest http://localhost:5000 -ErrorAction SilentlyContinue} catch{}
+  if ( ($r -ne $null) -and ($r.StatusCode -eq 200)) {
+    $loaded = $true
+    Write-Host "success!"
+    break
+  }
+  Start-Sleep -Seconds 10
+}
+
+if (-not $loaded){
+    exit 100
+}
+
+&"$netherRoot\run-integration-tests.ps1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ after_build:
 - ps:  Push-AppveyorArtifact commit.txt -FileName commit.txt -Type Auto
 test_script:
 - ps: ./run-unit-tests.ps1
+- ps: ./appveyor-run-with-integration-tests.ps1
 deploy:
 - provider: AzureBlob
   storage_account_name: netherartifacts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,14 @@ build_script:
 - gulp --version
 - ps: ./RunCodeFormatter.ps1
 - ps: ./build.ps1
-- ps: ./appveyor-packageweb.ps1
 - git rev-parse HEAD > commit.txt
-after_build:
-- ps:  Push-AppveyorArtifact src/Nether.Web/bin/Release/netcoreapp1.1/Nether.Web.zip -FileName Nether.Web.Zip -Type WebDeployPackage
-- ps:  Push-AppveyorArtifact commit.txt -FileName commit.txt -Type Auto
 test_script:
 - ps: ./run-unit-tests.ps1
 - ps: ./appveyor-run-with-integration-tests.ps1
+after_test:
+- ps: ./appveyor-packageweb.ps1
+- ps:  Push-AppveyorArtifact src/Nether.Web/bin/Release/netcoreapp1.1/Nether.Web.zip -FileName Nether.Web.Zip -Type WebDeployPackage
+- ps:  Push-AppveyorArtifact commit.txt -FileName commit.txt -Type Auto
 deploy:
 - provider: AzureBlob
   storage_account_name: netherartifacts

--- a/build/build-order.txt
+++ b/build/build-order.txt
@@ -4,3 +4,4 @@ src/TestClients/FacebookUserTokenClient
 src/TestClients/IdentityServerTestClient
 src/PerformanceTests/LeaderboardLoadTest
 tests/Nether.Web.UnitTests
+tests/Nether.Web.IntegrationTests


### PR DESCRIPTION
### Issue: 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Update the appveryor build to automatically run Nether.Web (with in-memory providers) and then run the integration tests

### Test:
Check that the appveyor build for the PR has run the integration tests