### PR TITLE
Add config switches for nether blocks/services

### DIFF
--- a/src/Nether.Web/Features/AdminWebUi/AdminWebUiController.cs
+++ b/src/Nether.Web/Features/AdminWebUi/AdminWebUiController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Nether.Web.Features.AdminWebUi
 {
     [Route("admin")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public class AdminWebUiController : Controller
     {
         [HttpGet]

--- a/src/Nether.Web/Features/Analytics/Controllers/AnalyticsController.cs
+++ b/src/Nether.Web/Features/Analytics/Controllers/AnalyticsController.cs
@@ -8,10 +8,12 @@ using Nether.Data.Analytics;
 using Nether.Web.Features.Analytics.Models.Analytics;
 using System.Linq;
 using System.Net;
+using Nether.Web.Utilities;
 
 namespace Nether.Web.Features.Analytics
 {
     [Route("analytics")]
+    [NetherService("Analytics")]
     [Authorize(Roles = RoleNames.Admin)]
     public class AnalyticsController : Controller
     {

--- a/src/Nether.Web/Features/Analytics/Controllers/EndpointController.cs
+++ b/src/Nether.Web/Features/Analytics/Controllers/EndpointController.cs
@@ -13,6 +13,7 @@ using Nether.Web.Features.Analytics.Models.Endpoint;
 namespace Nether.Web.Features.Analytics
 {
     [Route("endpoint")]
+    [NetherService("Analytics")]
     public class EndpointController : Controller
     {
         private readonly EndpointInfo _endpointInfo;

--- a/src/Nether.Web/Features/Identity/Controllers/IdentityTestController.cs
+++ b/src/Nether.Web/Features/Identity/Controllers/IdentityTestController.cs
@@ -3,12 +3,14 @@
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nether.Web.Utilities;
 using System.Linq;
 
 namespace Nether.Web.Features.Identity
 {
     [Route("identity-test")]
     [Authorize]
+    [NetherService("Identity")]
     public class IdentityTestController : ControllerBase
     {
         [HttpGet]

--- a/src/Nether.Web/Features/Identity/Controllers/UserController.cs
+++ b/src/Nether.Web/Features/Identity/Controllers/UserController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nether.Data.Identity;
 using Nether.Web.Features.Identity.Models;
 using Nether.Web.Features.Identity.Models.User;
+using Nether.Web.Utilities;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 namespace Nether.Web.Features.Identity
 {
     [Route("identity/users")]
+    [NetherService("Identity")]
     [Authorize(Roles = RoleNames.Admin)]
     public class UserController : ControllerBase
     {

--- a/src/Nether.Web/Features/Identity/Controllers/UserLoginController.cs
+++ b/src/Nether.Web/Features/Identity/Controllers/UserLoginController.cs
@@ -16,6 +16,7 @@ namespace Nether.Web.Features.Identity
 {
     [Route("identity/users/{userId}/logins")]
     [Authorize(Roles = RoleNames.Admin)]
+    [NetherService("Identity")]
     public class UserLoginController : ControllerBase
     {
         private readonly IUserStore _userStore;

--- a/src/Nether.Web/Features/IdentityUi/Account/AccountController.cs
+++ b/src/Nether.Web/Features/IdentityUi/Account/AccountController.cs
@@ -18,6 +18,7 @@ using IdentityModel;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Nether.Integration.Identity;
+using Nether.Web.Utilities;
 
 namespace Nether.Web.Features.IdentityUi
 {
@@ -27,6 +28,7 @@ namespace Nether.Web.Features.IdentityUi
     /// The interaction service provides a way for the UI to communicate with identityserver for validation and context retrieval
     /// </summary>
     [SecurityHeaders]
+    [NetherService("IdentityUi")]
     public class AccountController : Controller
     {
         private readonly IUserStore _userStore;

--- a/src/Nether.Web/Features/Leaderboard/Controllers/LeaderboardController.cs
+++ b/src/Nether.Web/Features/Leaderboard/Controllers/LeaderboardController.cs
@@ -25,6 +25,7 @@ namespace Nether.Web.Features.Leaderboard
     /// Leaderboard management
     /// </summary>
     [Route("leaderboards")]
+    [NetherService("Leaderboard")]
     public class LeaderboardController : Controller
     {
         private readonly ILeaderboardStore _store;

--- a/src/Nether.Web/Features/Leaderboard/Controllers/ScoreController.cs
+++ b/src/Nether.Web/Features/Leaderboard/Controllers/ScoreController.cs
@@ -20,6 +20,7 @@ namespace Nether.Web.Features.Leaderboard
     /// Leaderboard management
     /// </summary>
     [Route("scores")]
+    [NetherService("Leaderboard")]
     public class ScoreController : Controller
     {
         private readonly ILeaderboardStore _store;

--- a/src/Nether.Web/Features/PlayerManagement/Controllers/GroupAdminController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/GroupAdminController.cs
@@ -23,6 +23,7 @@ namespace Nether.Web.Features.PlayerManagement
     /// </summary>
     [Authorize(Roles = RoleNames.Admin)]
     [Route("admin/groups")]
+    [NetherService("PlayerManagement")]
     public class GroupAdminController : Controller
     {
         private readonly IPlayerManagementStore _store;

--- a/src/Nether.Web/Features/PlayerManagement/Controllers/GroupController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/GroupController.cs
@@ -23,6 +23,7 @@ namespace Nether.Web.Features.PlayerManagement
     /// </summary>
     [Authorize(Roles = RoleNames.Player)]
     [Route("groups")]
+    [NetherService("PlayerManagement")]
     public class GroupController : Controller
     {
         private readonly IPlayerManagementStore _store;

--- a/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerAdminController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerAdminController.cs
@@ -23,6 +23,7 @@ namespace Nether.Web.Features.PlayerManagement
     /// </summary>
     [Authorize(Roles = RoleNames.Admin)]
     [Route("admin/players")]
+    [NetherService("PlayerManagement")]
     public class PlayerAdminController : Controller
     {
         private readonly IPlayerManagementStore _store;

--- a/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerController.cs
@@ -23,6 +23,7 @@ namespace Nether.Web.Features.PlayerManagement
     /// </summary>
     [Authorize(Roles = RoleNames.Player)]
     [Route("player")]
+    [NetherService("PlayerManagement")]
     public class PlayerController : Controller
     {
         private readonly IPlayerManagementStore _store;

--- a/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerManagementIdentityController.cs
+++ b/src/Nether.Web/Features/PlayerManagement/Controllers/PlayerManagementIdentityController.cs
@@ -22,6 +22,7 @@ namespace Nether.Web.Features.PlayerManagement
     /// </summary>
     [ApiExplorerSettings(IgnoreApi = true)] // Suppress this from Swagger etc as it's designed to serve internal needs currently
     [Authorize(Policy = PolicyName.NetherIdentityClientId)] // only allow this to be called from the 'nether_identity' client
+    [NetherService("PlayerManagement")]
     public class PlayerManagementIdentityController : Controller
     {
         private readonly IPlayerManagementStore _store;

--- a/src/Nether.Web/Utilities/NetherServiceAttribute.cs
+++ b/src/Nether.Web/Utilities/NetherServiceAttribute.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nether.Web.Utilities
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class NetherServiceAttribute : // ******************* Currently hides the api.... need to disable it! ***********
+        Attribute,
+        IFilterFactory
+    {
+        public string Name { get; private set; }
+
+        public NetherServiceAttribute(string name)
+        {
+            Name = name;
+        }
+
+
+        bool IFilterFactory.IsReusable => false;
+
+        IFilterMetadata IFilterFactory.CreateInstance(IServiceProvider services)
+        {
+            // TODO resolve FeatureConfiguration class (needs creating, configuring and registering!)
+            var serviceSwitchSettings = services.GetRequiredService<NetherServiceSwitchSettings>();
+            return new InternalNetherServiceAttribute(serviceSwitchSettings, Name);
+        }
+
+        private class InternalNetherServiceAttribute : Attribute, IApiDescriptionVisibilityProvider, IFilterMetadata
+        {
+            public string _name;
+            private NetherServiceSwitchSettings _serviceSwitchSettings;
+
+            public InternalNetherServiceAttribute(NetherServiceSwitchSettings serviceSwitchSettings, string name)
+            {
+                _serviceSwitchSettings = serviceSwitchSettings;
+                _name = name;
+            }
+
+
+            bool IApiDescriptionVisibilityProvider.IgnoreApi
+            {
+                get { return !_serviceSwitchSettings.IsServiceEnabled(_name); }
+            }
+        }
+    }
+}

--- a/src/Nether.Web/Utilities/NetherServiceControllerFeatureProvider.cs
+++ b/src/Nether.Web/Utilities/NetherServiceControllerFeatureProvider.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace Nether.Web.Utilities
+{
+    /// <summary>
+    /// Filters out controllers with the NetherServiceAttribute if the service they represent isn't enabled in NetherServiceSwitchSettings
+    /// </summary>
+    public class NetherServiceControllerFeatureProvider : ControllerFeatureProvider
+    {
+        private readonly NetherServiceSwitchSettings _serviceSwitchSettings;
+
+        public NetherServiceControllerFeatureProvider(NetherServiceSwitchSettings netherServiceSwitchSettings)
+        {
+            _serviceSwitchSettings = netherServiceSwitchSettings;
+        }
+        protected override bool IsController(TypeInfo typeInfo)
+        {
+            if (!base.IsController(typeInfo))
+            {
+                // Standard logic doesn't consider it a controller
+                return false;
+            }
+
+            var netherServiceAttributeData = typeInfo.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(NetherServiceAttribute));
+
+            if (netherServiceAttributeData == null)
+            {
+                // No NetherServiceAttribute specified, so not restricted by Nether Service
+                return true;
+            }
+
+            // Get the serviceName and test if that service is enabled
+            string serviceName = (string)netherServiceAttributeData.ConstructorArguments[0].Value;
+            return _serviceSwitchSettings.IsServiceEnabled(serviceName);
+        }
+    }
+}

--- a/src/Nether.Web/Utilities/NetherServiceSwitchSettings.cs
+++ b/src/Nether.Web/Utilities/NetherServiceSwitchSettings.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nether.Web.Utilities
+{
+    public class NetherServiceSwitchSettings
+    {
+        private readonly Dictionary<string, bool> _serviceSwitches = new Dictionary<string, bool>();
+        public void AddServiceSwitch(string serviceName, bool enabled)
+        {
+            _serviceSwitches.Add(serviceName, enabled);
+        }
+        public bool IsServiceEnabled(string serviceName)
+        {
+            if (_serviceSwitches.TryGetValue(serviceName, out bool enabled))
+            {
+                return enabled;
+            }
+            return false; // assume not enabled if not registered
+        }
+    }
+}

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -6,6 +6,7 @@
         }
     },
     "Leaderboard": {
+        "Enabled" :  true,
         "Store": {
             "wellknown": "in-memory"
             // "wellknown": "sql",
@@ -47,6 +48,7 @@
         }
     },
     "Identity": {
+        "Enabled": true,
         "InitialSetup": {
             "AdminPassword": "N3therAdm1n" // This should be changed for deployment
         },
@@ -196,6 +198,7 @@
         "RedirectUrl": "http://localhost:5000/ui/admin"
     },
     "Analytics": {
+        "Enabled": true,
         // Add these configuration values via environment variables or override on deployment
         "EventHub": {
             "KeyName": "",
@@ -212,6 +215,7 @@
         }
     },
     "PlayerManagement": {
+        "Enabled": true,
         "Store": {
             "wellknown": "in-memory"
             // "wellknown": "sql",


### PR DESCRIPTION
### Issue: fixes #371

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Add NetherService attribute to identify the service that a controller belongs to.
Add NetherServiceSwitchSettings that stores which services are enabled
Add code to enable/disable controllers based on the service switches

### Test:
Build and run Nether.Web and make a request to an endpoint in the browser or powershell etc  Noting the 401 Not Authorized response.
Set Enabled to false for the service that owns that API method in appsettings.json and re-run Nether.Web. Make the call to the endpoint again and notice that you get 404 Not Found instead.
Also check the swagger ui to ensure that the API that you disabled doesn't show up.