### PR TITLE
Enable overriding config values with config/appsettings.json

### DIFF
--- a/documentation/configuration/README.md
+++ b/documentation/configuration/README.md
@@ -1,16 +1,17 @@
 # Configuration
 
-The configuration for Nether.Web is handled by `appsettings.json` and environment variables.
+To understand how you can specify configuration settings, see [overriding settings](overriding-settings.md).
 
-See the following articles for information on configuring different services in Nether
+
+To find out what settings you can specify see the following sections:
 
 * [Identity services](identity.md)
 * [Leaderboard](leaderboard.md)
 * [Player Management](player-management.md)
 * TODO Analytics
+* TODO Common
 
 
-There is also documentation on how to [override configuration settings using environment variables](appsettings-vs-env-vars.md) rather than by modifying `appsettings.json`.
 
 ## Disabling nether services
 

--- a/documentation/configuration/identity.md
+++ b/documentation/configuration/identity.md
@@ -25,7 +25,7 @@ IdentityBaseUrl | string | The base URL for the identity service. This defaults 
 ApiBaseUrl | string | The base URL for the Player Management API. This defaults to http://localhost:5000/api, but needs to be updated for deployment
 
 
-If you are not using the Nether Player Management services then you can create a client to integrate with your own Player Management services by implementing [IIdentityPlayerManagementClient](https://github.com/MicrosoftDX/nether/blob/master/src/Nether.Integration/Identity/IIdentityPlayerManagementClient.cs) and configure [dependency injection](../configuration-dependency-injection.md) to wire it up.
+If you are not using the Nether Player Management services then you can create a client to integrate with your own Player Management services by implementing [IIdentityPlayerManagementClient](https://github.com/MicrosoftDX/nether/blob/master/src/Nether.Integration/Identity/IIdentityPlayerManagementClient.cs) and configure [dependency injection](dependency-injection.md) to wire it up.
 
 ## Store
 The identity store defaults to an in-memory data store for ease of local configuration.

--- a/documentation/configuration/overriding-settings.md
+++ b/documentation/configuration/overriding-settings.md
@@ -1,7 +1,10 @@
-# Configuration in appsettings.json and environment variables
+# Overriding settings
 
+* [Overview of appsettings.json](overview-of-appsettings-json)
+* [Overriding configuration with config/appsettings.json](overriding-configuration-with-config-appsettings-json)
+* [Overriding configuration with environment variables](overriding-configuration-with-environment-variables)
 
-## AppSettings.json
+## Overview of appsettings.json
 
 The default configuration is specified in the appsettings.json under `src/Nether.Web`.
 
@@ -52,9 +55,17 @@ This JSON file contains a top-level property for each nether service (e.g. `lead
 Some aspects of the configuration relate to settings for the services, e.g. the `Identity:InitialSetup:AdminPassword`. Others are used to specify which dependencies should be wired up, e.g. `Leaderboard:Store`.
 In the case of dependencies, there is a common pattern that is followed that is discussed further in the [dependency injection docs](dependency-injection.md).
 
+## Overriding configuration with config/appsettings.json
+
+A quick way to modify your settings locally is to specify the values you want to override in the `appsettings.json` file in the `Nether.Web/config` folder. Any values specified in this file will override the defaults in `Nether.Web/appsettings.json`. Additionally, there is a `.gitignore` entry that prevents this file being committed to source control to help avoid accidentally adding secrets to source control when developing Nether.
+
+The config folder also has some sample configuration files, e.g. [appsettings-sql.sample.json](../../src/Nether.Web/config/appsettings-sql.sample.json)
 
 
 ## Overriding configuration with environment variables
+
+An alternative way to override settings is using environment variables.
+
 
 In the example above for the leaderboard store, the `in-memory` provider was specified using the `wellknown` property:
 

--- a/src/Nether.Web/Nether.Web.csproj
+++ b/src/Nether.Web/Nether.Web.csproj
@@ -67,6 +67,7 @@
 
   <ItemGroup>
     <Folder Include="Features\AdminWebUi\" />
+    <Folder Include="config\" />
   </ItemGroup>
 
 </Project>

--- a/src/Nether.Web/Startup.cs
+++ b/src/Nether.Web/Startup.cs
@@ -41,6 +41,7 @@ namespace Nether.Web
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddJsonFile($"config/appsettings.json", optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
 

--- a/src/Nether.Web/config/.gitignore
+++ b/src/Nether.Web/config/.gitignore
@@ -1,0 +1,3 @@
+# ignore appsettings.json in this folder
+# as it is an environment-specific override
+appsettings.json

--- a/src/Nether.Web/config/appsettings-sql.sample.json
+++ b/src/Nether.Web/config/appsettings-sql.sample.json
@@ -1,0 +1,34 @@
+﻿{
+    "Leaderboard": {
+        "Store": {
+            "wellknown": "sql",
+            "properties": {
+              "ConnectionString": "<connection string>"
+            }
+        }
+    },
+    "Identity": {
+        "Store": {
+            "wellknown": "sql",
+            "properties": {
+             "ConnectionString": "<connection string>"
+            }
+        }
+    },
+    "Analytics": {
+        "Store": {
+            "wellknown": "sql",
+            "properties": {
+             "ConnectionString": "<connection string>"
+            }
+        }
+    },
+    "PlayerManagement": {
+        "Store": {
+            "wellknown": "sql",
+            "properties": {
+              "ConnectionString": "<connection string>"
+            }
+        }
+    }
+}

--- a/src/Nether.Web/config/appsettings-sql.sample.json
+++ b/src/Nether.Web/config/appsettings-sql.sample.json
@@ -1,9 +1,14 @@
 ﻿{
+    /* 
+        Sample configuration overrides for configuring SQL Stores
+        The connection strings here work for LocalDb installed with Visual Studio,
+        but you can change them for your connection string
+     */
     "Leaderboard": {
         "Store": {
             "wellknown": "sql",
             "properties": {
-              "ConnectionString": "<connection string>"
+              "ConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=Nether;Integrated Security=True;Connect Timeout=30"
             }
         }
     },
@@ -11,7 +16,7 @@
         "Store": {
             "wellknown": "sql",
             "properties": {
-             "ConnectionString": "<connection string>"
+              "ConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=Nether;Integrated Security=True;Connect Timeout=30"
             }
         }
     },
@@ -19,7 +24,7 @@
         "Store": {
             "wellknown": "sql",
             "properties": {
-             "ConnectionString": "<connection string>"
+              "ConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=Nether;Integrated Security=True;Connect Timeout=30"
             }
         }
     },
@@ -27,7 +32,7 @@
         "Store": {
             "wellknown": "sql",
             "properties": {
-              "ConnectionString": "<connection string>"
+              "ConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=Nether;Integrated Security=True;Connect Timeout=30"
             }
         }
     }


### PR DESCRIPTION
### Issue: 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Add config lookup for config/appsettings.json
Add gitignore for config/appsettings.json to avoid it being committed to source control
Add appsettings-sql.sample.json that shows the settings you need to add to configure Nether.Web to use SQL stores

### Test:
Build and run Nether.Web - confirm that it starts ok without a config/appsettings.json file
Create an appsettings.json file to configure Nether to use SQL Stores (see docs), re-run and verify that Nether is using the SQL store specified