### PR TITLE
Re-enable travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ solution: Nether.sln
 dist: trusty
 sudo: required
 mono: none
-dotnet: 1.0.0-rc4-1-004771
+dotnet: 1.0.1
 script: 
 #   - ./RunCodeFormatter.sh
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ dist: trusty
 sudo: required
 mono: none
 dotnet: 1.0.1
+before_install:
+- sudo apt-get install nodejs
+- sudo npm install -g gulp bower
 script: 
 #   - ./RunCodeFormatter.sh
+  - npm install -g gulp bower
   - ./build.sh
   - ./run-unit-tests.sh

--- a/build.sh
+++ b/build.sh
@@ -74,10 +74,9 @@ then
 else
   echo "*** Installing npm/bower packages..."
 
-  # check node.js and NPM are installed
-  command -v nodejs >/dev/null 2>&1 || { echo >&2 "Node.js is not installed. Aborting."; exit 1;}
+  # check NPM, bower and gulp are installed
   command -v npm >/dev/null 2>&1 || { echo >&2 "NPM is not installed. Aborting."; exit 1;}
-  command -v npm >/dev/null 2>&1 || { echo >&2 "bower is not installed (run npm install -g bower). Aborting."; exit 1;}
+  command -v bower >/dev/null 2>&1 || { echo >&2 "bower is not installed (run npm install -g bower). Aborting."; exit 1;}
   command -v gulp >/dev/null 2>&1 || { echo >&2 "gulp is not installed (run npm install -g gulp). Aborting."; exit 1;}
 
   buildExitCode=0


### PR DESCRIPTION
### Issue: #PutYourIssueNumberHere

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Travis now has support for csproj-based projects, so re-enabling the travis build and updating the build configuration to account for changes in the build process

### Test:
Verify that the travis build was triggered for the PR and completed successfully