### PR TITLE
Reuse AnalyticsIntegrationEventHubClient instance

### DIFF
--- a/src/Nether.Web/Features/Leaderboard/LeaderboardServiceExtensions.cs
+++ b/src/Nether.Web/Features/Leaderboard/LeaderboardServiceExtensions.cs
@@ -77,7 +77,7 @@ namespace Nether.Web.Features.Leaderboard
                             var scopedConfiguration = configuration.GetSection("Leaderboard:AnalyticsIntegrationClient:properties");
                             string eventHubConnectionString = scopedConfiguration["EventHubConnectionString"];
 
-                            services.AddTransient<IAnalyticsIntegrationClient>(serviceProvider =>
+                            services.AddSingleton<IAnalyticsIntegrationClient>(serviceProvider =>
                             {
                                 return new AnalyticsIntegrationEventHubClient(eventHubConnectionString);
                             });


### PR DESCRIPTION
### Issue: closes #397 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Change the DI config for AnalyticsIntegrationEventHubClient to singleton so that the instance is re-used. The class internall re-uses the EventHubClient instance, so this change will reduce the EventHubClient instance creation

### Test:
Run the load tests and check that the SocketException no longer occurs