### PR TITLE
Add AppInsights and events

### DIFF
--- a/documentation/configuration/README.md
+++ b/documentation/configuration/README.md
@@ -5,28 +5,8 @@ To understand how you can specify configuration settings, see [overriding settin
 
 To find out what settings you can specify see the following sections:
 
+* [Common configuration](common.md)
 * [Identity services](identity.md)
 * [Leaderboard](leaderboard.md)
 * [Player Management](player-management.md)
 * TODO Analytics
-* TODO Common
-
-
-
-## Disabling nether services
-
-Each service in Nether is designed to be self-contained, so while they are all packaged in Nether.Web the aim is that you can enable and disable each individual service. In the config, each service has an `Enabled` property that determines whether that service will be run.
-
-E.g.
-
-```json
- {
-     "Leaderboard": {
-        "Enabled": true,
-        "Store": {
-            "wellknown": "in-memory"
-        },
-        // config omitted
-    }
- }
-```

--- a/documentation/configuration/common.md
+++ b/documentation/configuration/common.md
@@ -1,0 +1,79 @@
+# Common configuration
+
+The examples here show the config options for the `appsettings.json` file - see [this documentation](overriding-settings.md) for how to override the settings.
+
+## Disabling nether services
+
+Each service in Nether is designed to be self-contained, so while they are all packaged in Nether.Web the aim is that you can enable and disable each individual service. In the config, each service has an `Enabled` property that determines whether that service will be run.
+
+E.g.
+
+```json
+ {
+     "Leaderboard": {
+        "Enabled": true,
+        "Store": {
+            "wellknown": "in-memory"
+        },
+        // config omitted
+    }
+ }
+```
+
+
+
+## CORS
+
+If you want to be able to access the Nether APIs from a web application hosted from a different domain then you will need to configure [CORS](https://www.w3.org/TR/cors/) for Nether. To do this, set the 
+
+```json
+{
+    "Common": {
+        "Cors": {
+            // Add CORS origins to allow here (or via environment variables)
+            "AllowedOrigins": []
+        }
+    }
+}
+```
+
+## Application Performance Monitor
+
+Nether has the ability to send telemetry to Application Performance Monitoring solutions. Out of the box we have support for [Application Insights](https://docs.microsoft.com/azure/application-insights/) but there is an abstraction to allow other providers to be [plugged in](dependency-injection.md).
+
+### Configuring Application Insights
+
+This section assumes that you have an instance of Application Insights, if not [create one first](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-create-new-resource).
+
+
+To configure Application Insights, set the `wellknown` value to `appinsights` as shown below.
+
+Then set `properties:InstrumentationKey` to the instrumentation key for your Application Insights instacen (See how to [get your instrumentation key](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-create-new-resource#copy-the-instrumentation-key))
+
+```json
+{
+    "Common": {
+        "ApplicationPerformanceMonitor": {
+            "wellknown": "appinsights",
+            "properties" : {
+                "InstrumentationKey": "<your key here>"
+            }
+        }
+    }
+}
+```
+
+
+### Disabling Application Performance Monitoring
+
+To disable Application Performance Monitoring, set the `wellknown` value to `null`:
+
+```json
+{
+    "Common": {
+        "ApplicationPerformanceMonitor": {
+            "wellknown": "null"
+        }
+    }
+}
+```

--- a/src/Nether.Common/ApplicationPerformanceMonitoring/ApplicationInsightsMonitor.cs
+++ b/src/Nether.Common/ApplicationPerformanceMonitoring/ApplicationInsightsMonitor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nether.Common.ApplicationPerformanceMonitoring
+{
+    //
+    public class ApplicationInsightsMonitor : IApplicationPerformanceMonitor
+    {
+        private readonly TelemetryClient _telemetryClient;
+
+        public ApplicationInsightsMonitor(TelemetryClient telemetryClient)
+        {
+            _telemetryClient = telemetryClient;
+        }
+
+        public void LogError(Exception exception, string message = null, IDictionary<string, string> properties = null)
+        {
+            var telemetry = new ExceptionTelemetry(exception);
+            AddProperties(telemetry, message, properties);
+            _telemetryClient.TrackException(telemetry);
+        }
+
+        public void LogEvent(string eventName, string message = null, IDictionary<string, string> properties = null)
+        {
+            var telemetry = new EventTelemetry(eventName);
+            AddProperties(telemetry, message, properties);
+            _telemetryClient.TrackEvent(telemetry);
+        }
+
+        private static void AddProperties(ISupportProperties eventTelemetry, string message, IDictionary<string, string> properties)
+        {
+            if (message != null)
+            {
+                eventTelemetry.Properties.Add("_Message", message);
+            }
+            if (properties != null)
+            {
+                foreach (var item in properties)
+                {
+                    eventTelemetry.Properties.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/src/Nether.Common/ApplicationPerformanceMonitoring/IApplicationPerformanceMonitor.cs
+++ b/src/Nether.Common/ApplicationPerformanceMonitoring/IApplicationPerformanceMonitor.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Nether.Common.ApplicationPerformanceMonitoring
+{
+    public interface IApplicationPerformanceMonitor
+    {
+        void LogEvent(string eventName, string message = null, IDictionary<string, string> properties = null);
+        void LogError(Exception exception, string message = null, IDictionary<string, string> properties = null);
+    }
+}

--- a/src/Nether.Common/ApplicationPerformanceMonitoring/NullMonitor.cs
+++ b/src/Nether.Common/ApplicationPerformanceMonitoring/NullMonitor.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nether.Common.ApplicationPerformanceMonitoring
+{
+    public class NullMonitor : IApplicationPerformanceMonitor
+    {
+        public void LogEvent(string eventName, string message = null, IDictionary<string, string> properties = null) { }
+        public void LogError(Exception exception, string message = null, IDictionary<string, string> properties = null) { }
+    }
+}

--- a/src/Nether.Common/Nether.Common.csproj
+++ b/src/Nether.Common/Nether.Common.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />

--- a/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
+++ b/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
@@ -22,6 +22,7 @@ using Nether.Integration.Identity;
 using Microsoft.AspNetCore.Builder;
 using System.IdentityModel.Tokens.Jwt;
 using Nether.Web.Utilities;
+using Nether.Common.ApplicationPerformanceMonitoring;
 
 namespace Nether.Web.Features.Identity
 {
@@ -29,9 +30,11 @@ namespace Nether.Web.Features.Identity
     {
         public static void EnsureInitialAdminUser(this IApplicationBuilder app, IConfiguration configuration, ILogger logger)
         {
+            IApplicationPerformanceMonitor appMonitor = null;
             try
             {
                 var serviceProvider = app.ApplicationServices;
+                appMonitor = serviceProvider.GetService<IApplicationPerformanceMonitor>();
 
                 logger.LogInformation("Identity:Store: Checking user store...");
 
@@ -70,6 +73,7 @@ namespace Nether.Web.Features.Identity
             catch (Exception ex)
             {
                 logger.LogCritical("Identity:Store: Adding initial admin user, exception: {0}", ex);
+                appMonitor.LogError(ex, "Error adding initial admin user");
             }
         }
 

--- a/src/Nether.Web/Features/Identity/StoreBackedProfileService.cs
+++ b/src/Nether.Web/Features/Identity/StoreBackedProfileService.cs
@@ -16,6 +16,7 @@ using Nether.Data.Identity;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Nether.Integration.Identity;
+using Nether.Common.ApplicationPerformanceMonitoring;
 
 namespace Nether.Web.Features.Identity
 {
@@ -24,14 +25,17 @@ namespace Nether.Web.Features.Identity
         private readonly IUserStore _userStore;
         private readonly UserClaimsProvider _userClaimsProvider;
         private readonly ILogger _logger;
+        private readonly IApplicationPerformanceMonitor _appMonitor;
 
         public StoreBackedProfileService(
             IUserStore userStore,
             UserClaimsProvider userClaimsProvider,
+            IApplicationPerformanceMonitor appMonitor,
             ILogger<StoreBackedProfileService> logger)
         {
             _userStore = userStore;
             _userClaimsProvider = userClaimsProvider;
+            _appMonitor = appMonitor;
             _logger = logger;
         }
         public async Task GetProfileDataAsync(ProfileDataRequestContext context)

--- a/src/Nether.Web/Features/Leaderboard/Controllers/LeaderboardController.cs
+++ b/src/Nether.Web/Features/Leaderboard/Controllers/LeaderboardController.cs
@@ -16,6 +16,7 @@ using System.Net;
 using Microsoft.Extensions.Logging;
 using Nether.Analytics.GameEvents;
 using Nether.Web.Features.Leaderboard.Models.Leaderboard;
+using Nether.Common.ApplicationPerformanceMonitoring;
 
 // For more information on enabling Web API for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -30,16 +31,20 @@ namespace Nether.Web.Features.Leaderboard
     {
         private readonly ILeaderboardStore _store;
         private readonly ILogger<LeaderboardController> _logger;
+        private readonly IApplicationPerformanceMonitor _appMonitor;
+
         private readonly ILeaderboardConfiguration _leaderboardConfiguration;
 
         public LeaderboardController(
             ILeaderboardStore store,
             ILogger<LeaderboardController> logger,
+            IApplicationPerformanceMonitor appMonitor,
             ILeaderboardConfiguration leaderboardConfiguration
             )
         {
             _store = store;
             _logger = logger;
+            _appMonitor = appMonitor;
             _leaderboardConfiguration = leaderboardConfiguration;
         }
 
@@ -53,8 +58,6 @@ namespace Nether.Web.Features.Leaderboard
         [HttpGet("")]
         public IActionResult GetAll()
         {
-            var gamerTag = User.GetGamerTag();
-
             var leaderboards = _leaderboardConfiguration.GetAll();
 
             return Ok(new LeaderboardListResponseModel
@@ -82,6 +85,10 @@ namespace Nether.Web.Features.Leaderboard
         public async Task<IActionResult> Get(string name)
         {
             var gamertag = User.GetGamerTag();
+
+            _appMonitor.LogEvent("Leaderboard", properties: new Dictionary<string, string> {
+                { "Name", name }
+            });
 
             LeaderboardConfig config = _leaderboardConfiguration.GetByName(name);
             if (config == null)

--- a/src/Nether.Web/Nether.Web.csproj
+++ b/src/Nether.Web/Nether.Web.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="1.0.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="1.0.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="1.1.0" />

--- a/src/Nether.Web/Startup.cs
+++ b/src/Nether.Web/Startup.cs
@@ -64,6 +64,7 @@ namespace Nether.Web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IConfiguration>(Configuration);
+            services.AddApplicationPerformanceMonitoring(Configuration, _logger, _hostingEnvironment);
 
             // Initialize switches for nether services
             var serviceSwitches = new NetherServiceSwitchSettings();

--- a/src/Nether.Web/Utilities/ApplicationPerformanceMonitoringExtensions.cs
+++ b/src/Nether.Web/Utilities/ApplicationPerformanceMonitoringExtensions.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+using IdentityServer4.Services;
+using IdentityServer4.Validation;
+
+using Nether.Data.Identity;
+using Nether.Web.Features.Identity.Configuration;
+using Nether.Common.DependencyInjection;
+using Nether.Data.Sql.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using IdentityServer4.Models;
+using System.Collections.Generic;
+using Nether.Integration.Identity;
+using Microsoft.AspNetCore.Builder;
+using System.IdentityModel.Tokens.Jwt;
+using Nether.Common.ApplicationPerformanceMonitoring;
+
+namespace Nether.Web.Features.Identity
+{
+    public static class ApplicationPerformanceMonitoringExtensions
+    {
+        public static IServiceCollection AddApplicationPerformanceMonitoring(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            ILogger logger,
+            IHostingEnvironment hostingEnvironment)
+        {
+            ConfigureApplicationPerformanceMonitor(services, configuration, logger, hostingEnvironment);
+
+            return services;
+        }
+
+        private static void ConfigureApplicationPerformanceMonitor(
+            IServiceCollection services,
+            IConfiguration configuration,
+            ILogger logger,
+            IHostingEnvironment hostingEnvironment)
+        {
+            if (configuration.Exists("Common:ApplicationPerformanceMonitor:wellKnown"))
+            {
+                // register using well-known type
+                var wellKnownType = configuration["Common:ApplicationPerformanceMonitor:wellknown"];
+                var scopedConfiguration = configuration.GetSection("Common:ApplicationPerformanceMonitor:properties");
+                switch (wellKnownType)
+                {
+                    case "null":
+                        logger.LogInformation("Common:ApplicationPerformanceMonitor: using 'null' client");
+                        services.AddSingleton<IApplicationPerformanceMonitor, NullMonitor>();
+                        break;
+
+                    case "appinsights":
+                        var instrumentationKey = scopedConfiguration["InstrumentationKey"];
+                        logger.LogInformation("Common:ApplicationPerformanceMonitor: using 'appinsights' client with InstrumentationKey '{0}'", instrumentationKey);
+
+                        services.AddApplicationInsightsTelemetry(options =>
+                        {
+                            options.DeveloperMode = hostingEnvironment.EnvironmentName == "Development";
+                            options.InstrumentationKey = instrumentationKey;
+                        });
+
+                        services.AddTransient<IApplicationPerformanceMonitor, ApplicationInsightsMonitor>();
+                        break;
+
+                    default:
+                        throw new Exception($"Unhandled 'wellKnown' type for Common:ApplicationPerformanceMonitor: '{wellKnownType}'");
+                }
+            }
+            else
+            {
+                // fall back to generic "factory"/"implementation" configuration
+                services.AddServiceFromConfiguration<IUserStore>(configuration, logger, "Common:ApplicationPerformanceMonitor");
+            }
+        }
+    }
+}

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -1,227 +1,230 @@
-﻿{
-    "Common": {
-        "Cors": {
-            // Add CORS origins to allow here (or via environment variables)
-            "AllowedOrigins": []
-        }
+{
+  "Common": {
+    "Cors": {
+      // Add CORS origins to allow here (or via environment variables)
+      "AllowedOrigins": []
     },
-    "Leaderboard": {
-        "Enabled" :  true,
-        "Store": {
-            "wellknown": "in-memory"
-            // "wellknown": "sql",
-            // "properties": {
-            //   "ConnectionString": "<connection string>"
-            // }
-        },
-        "AnalyticsIntegrationClient": {
-            "wellknown": "null"
-            // "wellknown": "http",
-            // "properties": {
-            //     "AnalyticsBaseUrl": "http://localhost:5000/api/"
-            // }
-            // "wellknown": "eventhub",
-            // "properties": {
-            //     "EventHubConnectionString": "<connection string>"
-            // }
-        },
-        "Leaderboards": {
-            "Default": {
-                "Type": "All",
-                "IncludeCurrentPlayer": true
-            },
-            "5_AroundMe": {
-                "Type": "AroundMe",
-                "Radius": 5,
-                "IncludeCurrentPlayer": true
-            },
-            "Top_5": {
-                "Type": "Top",
-                "Top": 5,
-                "IncludeCurrentPlayer": true
-            },
-            "Top_10": {
-                "Type": "Top",
-                "Top": 10,
-                "IncludeCurrentPlayer": true
-            }
-        }
-    },
-    "Identity": {
-        "Enabled": true,
-        "InitialSetup": {
-            "AdminPassword": "N3therAdm1n" // This should be changed for deployment
-        },
-        "PlayerManagementClient": {
-            "wellknown": "default",
-            "properties": {
-                "IdentityBaseUrl": "http://localhost:5000/identity",
-                "ApiBaseUrl": "http://localhost:5000/api"
-            }
-        },
-        "Store": {
-            "wellknown": "in-memory"
-            //"wellknown": "sql",
-            //"properties": {
-            //  "ConnectionString": "<connection string>"
-            //}
-        },
-        "IdentityServer": {
-            "Authority": "http://localhost:5000/identity",
-            "RequireHttps": true, // This is overridden to false for dev environments but should be true for production!
-            "UiBaseUrl": "http://localhost:5000/ui"
-        },
-        "SignInMethods": {
-            // Facebook in-browser, interactive flow
-            "Facebook": {
-                "Enabled": false,
-                "AppId": "",
-                "AppSecret": ""
-            },
-            // the custom facebook token flow (e.g. from Unity)
-            "FacebookUserAccessToken": {
-                "Enabled": false,
-                "AppToken": ""
-            }
-            // TODO - generic OpenIdConnect, ...
-        },
-        "Clients": {
-            // TODO - client secrets should be recreated when deploying!
-            "nether_identity": {
-                // client used to by the PlayerManagementClient (Identity integration to PlayerManagement)
-                "AllowedGrantTypes": [
-                    "client_credentials"
-                ],
-                "AllowedScopes": [
-                    "nether-all"
-                ],
-                "ClientSecrets": [
-                    "FSduhU3J6TVcLGLiWxic"
-                ] // This should be changed when deploying!
-            },
-            "swaggerui": {
-                "Name": "SwaggerUI client",
-                "AllowedGrantTypes": [
-                    "implicit"
-                ],
-                "ClientSecrets": [
-                    "swaggeruisecret"
-                ],
-                "AllowAccessTokensViaBrowser": true,
-                "AllowedScopes": [
-                    "openid",
-                    "profile",
-                    "nether-all"
-                ],
-                "RedirectUris": [
-                    "http://localhost:5000/api/swagger/ui/o2c.html"
-                ]
-            },
-            "devclient": {
-                "Name": "Dev Client",
-                "AllowedGrantTypes": [
-                    "hybrid",
-                    "password",
-                    "fb-usertoken"
-                ],
-                "RedirectUris": [
-                    "http://localhost:5000/signin-oidc"
-                ],
-                "PostLogoutRedirectUris": [
-                    "http://localhost:5000/"
-                ],
-                "ClientSecrets": [
-                    "devsecret"
-                ], // TODO: should this be plain, or Sha-hashed?
-                "AllowedScopes": [
-                    "openid",
-                    "profile",
-                    "nether-all"
-                ]
-            },
-            "angular2client": {
-                "Name": "angular2client",
-                "AccessTokenType": "Reference",
-                "AllowedGrantTypes": [
-                    "implicit"
-                ],
-                "AllowAccessTokensViaBrowser": true,
-                "RedirectUris": [
-                    "http://localhost:5000"
-                ],
-                "PostLogoutRedirectUris": [
-                    "http://localhost:5000/login"
-                ],
-                "AllowedCorsOrigins": [
-                    "http://localhost:5000",
-                    "https://localhost:5000"
-                ],
-                "ClientSecrets": [
-                    "devsecret"
-                ], // TODO: should this be plain, or Sha-hashed?
-                "AllowedScopes": [
-                    "openid",
-                    "profile",
-                    "nether-all"
-                ]
-            },
-            "jstest": {
-                "Name": "JavaScript Client",
-                "AllowedGrantTypes": [
-                    "implicit"
-                ],
-                "AllowAccessTokensViaBrowser": true,
-                "RedirectUris": [
-                    "http://localhost:5000/ui/features/identity-test/callback.html"
-                ],
-                "PostLogoutRedirectUris": [
-                    "http://localhost:5000/ui/features/identity-test/index.html"
-                ],
-                "AllowedCorsOrigins": [
-                    "http://localhost:5000",
-                    "https://localhost:5000"
-                ],
-                "ClientSecrets": [
-                    "jssecret"
-                ], // TODO: should this be plain, or Sha-hashed?
-                "AllowedScopes": [
-                    "openid",
-                    "profile",
-                    "nether-all"
-                ]
-            }
-        }
-    },
-    "AdminWebUi": {
-        "AuthServerUrl": "http://localhost:5000/identity",
-        "ApiBaseUrl": "http://localhost:5000/api",
-        "RedirectUrl": "http://localhost:5000/ui/admin"
-    },
-    "Analytics": {
-        "Enabled": true,
-        // Add these configuration values via environment variables or override on deployment
-        "EventHub": {
-            "KeyName": "",
-            "AccessKey": "",
-            "Resource": "",
-            "Ttl": "24:00:00"
-        },
-        "Store": {
-            "wellknown": "in-memory"
-            //"wellknown": "sql",
-            //"properties": {
-            //  "ConnectionString": "<connection string>"
-            //}
-        }
-    },
-    "PlayerManagement": {
-        "Enabled": true,
-        "Store": {
-            "wellknown": "in-memory"
-            // "wellknown": "sql",
-            // "properties": {
-            //   "ConnectionString": "<connection string>"
-            // }
-        }
+    "ApplicationPerformanceMonitor": {
+      "wellknown": "null"
     }
+  },
+  "Leaderboard": {
+    "Enabled": true,
+    "Store": {
+      "wellknown": "in-memory"
+      // "wellknown": "sql",
+      // "properties": {
+      //   "ConnectionString": "<connection string>"
+      // }
+    },
+    "AnalyticsIntegrationClient": {
+      "wellknown": "null"
+      // "wellknown": "http",
+      // "properties": {
+      //     "AnalyticsBaseUrl": "http://localhost:5000/api/"
+      // }
+      // "wellknown": "eventhub",
+      // "properties": {
+      //     "EventHubConnectionString": "<connection string>"
+      // }
+    },
+    "Leaderboards": {
+      "Default": {
+        "Type": "All",
+        "IncludeCurrentPlayer": true
+      },
+      "5_AroundMe": {
+        "Type": "AroundMe",
+        "Radius": 5,
+        "IncludeCurrentPlayer": true
+      },
+      "Top_5": {
+        "Type": "Top",
+        "Top": 5,
+        "IncludeCurrentPlayer": true
+      },
+      "Top_10": {
+        "Type": "Top",
+        "Top": 10,
+        "IncludeCurrentPlayer": true
+      }
+    }
+  },
+  "Identity": {
+    "Enabled": true,
+    "InitialSetup": {
+      "AdminPassword": "N3therAdm1n" // This should be changed for deployment
+    },
+    "PlayerManagementClient": {
+      "wellknown": "default",
+      "properties": {
+        "IdentityBaseUrl": "http://localhost:5000/identity",
+        "ApiBaseUrl": "http://localhost:5000/api"
+      }
+    },
+    "Store": {
+      "wellknown": "in-memory"
+      //"wellknown": "sql",
+      //"properties": {
+      //  "ConnectionString": "<connection string>"
+      //}
+    },
+    "IdentityServer": {
+      "Authority": "http://localhost:5000/identity",
+      "RequireHttps": true, // This is overridden to false for dev environments but should be true for production!
+      "UiBaseUrl": "http://localhost:5000/ui"
+    },
+    "SignInMethods": {
+      // Facebook in-browser, interactive flow
+      "Facebook": {
+        "Enabled": false,
+        "AppId": "",
+        "AppSecret": ""
+      },
+      // the custom facebook token flow (e.g. from Unity)
+      "FacebookUserAccessToken": {
+        "Enabled": false,
+        "AppToken": ""
+      }
+      // TODO - generic OpenIdConnect, ...
+    },
+    "Clients": {
+      // TODO - client secrets should be recreated when deploying!
+      "nether_identity": {
+        // client used to by the PlayerManagementClient (Identity integration to PlayerManagement)
+        "AllowedGrantTypes": [
+          "client_credentials"
+        ],
+        "AllowedScopes": [
+          "nether-all"
+        ],
+        "ClientSecrets": [
+          "FSduhU3J6TVcLGLiWxic"
+        ] // This should be changed when deploying!
+      },
+      "swaggerui": {
+        "Name": "SwaggerUI client",
+        "AllowedGrantTypes": [
+          "implicit"
+        ],
+        "ClientSecrets": [
+          "swaggeruisecret"
+        ],
+        "AllowAccessTokensViaBrowser": true,
+        "AllowedScopes": [
+          "openid",
+          "profile",
+          "nether-all"
+        ],
+        "RedirectUris": [
+          "http://localhost:5000/api/swagger/ui/o2c.html"
+        ]
+      },
+      "devclient": {
+        "Name": "Dev Client",
+        "AllowedGrantTypes": [
+          "hybrid",
+          "password",
+          "fb-usertoken"
+        ],
+        "RedirectUris": [
+          "http://localhost:5000/signin-oidc"
+        ],
+        "PostLogoutRedirectUris": [
+          "http://localhost:5000/"
+        ],
+        "ClientSecrets": [
+          "devsecret"
+        ], // TODO: should this be plain, or Sha-hashed?
+        "AllowedScopes": [
+          "openid",
+          "profile",
+          "nether-all"
+        ]
+      },
+      "angular2client": {
+        "Name": "angular2client",
+        "AccessTokenType": "Reference",
+        "AllowedGrantTypes": [
+          "implicit"
+        ],
+        "AllowAccessTokensViaBrowser": true,
+        "RedirectUris": [
+          "http://localhost:5000"
+        ],
+        "PostLogoutRedirectUris": [
+          "http://localhost:5000/login"
+        ],
+        "AllowedCorsOrigins": [
+          "http://localhost:5000",
+          "https://localhost:5000"
+        ],
+        "ClientSecrets": [
+          "devsecret"
+        ], // TODO: should this be plain, or Sha-hashed?
+        "AllowedScopes": [
+          "openid",
+          "profile",
+          "nether-all"
+        ]
+      },
+      "jstest": {
+        "Name": "JavaScript Client",
+        "AllowedGrantTypes": [
+          "implicit"
+        ],
+        "AllowAccessTokensViaBrowser": true,
+        "RedirectUris": [
+          "http://localhost:5000/ui/features/identity-test/callback.html"
+        ],
+        "PostLogoutRedirectUris": [
+          "http://localhost:5000/ui/features/identity-test/index.html"
+        ],
+        "AllowedCorsOrigins": [
+          "http://localhost:5000",
+          "https://localhost:5000"
+        ],
+        "ClientSecrets": [
+          "jssecret"
+        ], // TODO: should this be plain, or Sha-hashed?
+        "AllowedScopes": [
+          "openid",
+          "profile",
+          "nether-all"
+        ]
+      }
+    }
+  },
+  "AdminWebUi": {
+    "AuthServerUrl": "http://localhost:5000/identity",
+    "ApiBaseUrl": "http://localhost:5000/api",
+    "RedirectUrl": "http://localhost:5000/ui/admin"
+  },
+  "Analytics": {
+    "Enabled": true,
+    // Add these configuration values via environment variables or override on deployment
+    "EventHub": {
+      "KeyName": "",
+      "AccessKey": "",
+      "Resource": "",
+      "Ttl": "24:00:00"
+    },
+    "Store": {
+      "wellknown": "in-memory"
+      //"wellknown": "sql",
+      //"properties": {
+      //  "ConnectionString": "<connection string>"
+      //}
+    }
+  },
+  "PlayerManagement": {
+    "Enabled": true,
+    "Store": {
+      "wellknown": "in-memory"
+      // "wellknown": "sql",
+      // "properties": {
+      //   "ConnectionString": "<connection string>"
+      // }
+    }
+  }
 }

--- a/tests/Nether.Web.UnitTests/Features/Leaderboard/LeaderboardControllerTests.cs
+++ b/tests/Nether.Web.UnitTests/Features/Leaderboard/LeaderboardControllerTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 using IdentityModel;
 using Microsoft.Extensions.Logging;
 using Nether.Web.Features.Leaderboard.Models.Score;
+using Nether.Common.ApplicationPerformanceMonitoring;
 
 namespace Nether.Web.UnitTests.Features.Leaderboard
 {
@@ -35,6 +36,7 @@ namespace Nether.Web.UnitTests.Features.Leaderboard
                     services.Setup(s => s.GetService(typeof(ILeaderboardStore))).Returns(leaderboardStore.Object);
                     services.Setup(s => s.GetService(typeof(IAnalyticsIntegrationClient))).Returns(Mock.Of<IAnalyticsIntegrationClient>());
                     services.Setup(s => s.GetService(typeof(ILogger<ScoreController>))).Returns(Mock.Of<ILogger<ScoreController>>());
+                    services.Setup(s => s.GetService(typeof(IApplicationPerformanceMonitor))).Returns(new NullMonitor());
                 });
 
             // Act
@@ -58,6 +60,7 @@ namespace Nether.Web.UnitTests.Features.Leaderboard
                     services.Setup(s => s.GetService(typeof(ILeaderboardStore))).Returns(leaderboardStore.Object);
                     services.Setup(s => s.GetService(typeof(IAnalyticsIntegrationClient))).Returns(Mock.Of<IAnalyticsIntegrationClient>());
                     services.Setup(s => s.GetService(typeof(ILogger<ScoreController>))).Returns(Mock.Of<ILogger<ScoreController>>());
+                    services.Setup(s => s.GetService(typeof(IApplicationPerformanceMonitor))).Returns(new NullMonitor());
                 }
             );
 
@@ -85,6 +88,7 @@ namespace Nether.Web.UnitTests.Features.Leaderboard
                     services.Setup(s => s.GetService(typeof(ILeaderboardStore))).Returns(leaderboardStore.Object);
                     services.Setup(s => s.GetService(typeof(IAnalyticsIntegrationClient))).Returns(Mock.Of<IAnalyticsIntegrationClient>());
                     services.Setup(s => s.GetService(typeof(ILogger<ScoreController>))).Returns(Mock.Of<ILogger<ScoreController>>());
+                    services.Setup(s => s.GetService(typeof(IApplicationPerformanceMonitor))).Returns(new NullMonitor());
                 },
                 user: new ClaimsPrincipal(
                         new ClaimsIdentity(new[]


### PR DESCRIPTION
### Issue: 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Add AppInsights with an abstraction intended to allow other similar providers to be plugged in.
Add some initial events as a starting point - more to be added as we start working out what we need

### Test:
The AppVeyor build runs the in-memory integration tests. The default configuration has App Insights turned off, so the appveyor build confirms that this is working for the integration tests

Configure App Insights as per the updated documentation in this PR (see https://github.com/stuartleeks/nether/blob/app-insights/documentation/configuration/common.md#configuring-application-insights)
Build and run Nether.Web
Run integration tests to confirm working with App Insights configured. Also verify that events are being submitted to App Insights