### PR TITLE
Add option for HTTPS redirect

### DIFF
--- a/deployment/nether-deploy-web.json
+++ b/deployment/nether-deploy-web.json
@@ -224,6 +224,7 @@
                     "WEB_HOST_URL": "[concat('https://', reference(variables('webSiteName')).hostNames[0])]",
                     "ASPNETCORE_ENVIRONMENT": "Development",
                     "Common:Cors:AllowedOrigins": "",
+                    "Common:RedirectToHttps": "true",
 
                     /* Leaderboard feature config overrides */
                     "Leaderboard:Store:wellknown": "sql",

--- a/documentation/configuration/common.md
+++ b/documentation/configuration/common.md
@@ -37,9 +37,25 @@ If you want to be able to access the Nether APIs from a web application hosted f
 }
 ```
 
+## HTTPS Redirection
+
+When running for production purposes, HTTPS should be used as per the [OAuth 2.0 spec](https://tools.ietf.org/html/rfc6749).
+
+To simplify working with Nether, you can configure it to issue HTTP redirects for any plain HTTP requests to HTTPS. This is configured through the setting shown below:
+
+```json
+{
+    "Common": {
+        "RedirectToHttps" : true
+    }
+}
+```
+
+
 ## Application Performance Monitor
 
 Nether has the ability to send telemetry to Application Performance Monitoring solutions. Out of the box we have support for [Application Insights](https://docs.microsoft.com/azure/application-insights/) but there is an abstraction to allow other providers to be [plugged in](dependency-injection.md).
+
 
 ### Configuring Application Insights
 

--- a/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
+++ b/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
@@ -152,7 +152,7 @@ namespace Nether.Web.Features.Identity
             ILogger logger,
             IHostingEnvironment hostingEnvironment)
         {
-            if (hostingEnvironment.EnvironmentName != "Development")
+            if (!hostingEnvironment.IsDevelopment())
             {
                 throw new NotSupportedException($"The Identity Server configuration is currently only intended for Development environments. Current environment: '{hostingEnvironment.EnvironmentName}'");
             }

--- a/src/Nether.Web/Nether.Web.csproj
+++ b/src/Nether.Web/Nether.Web.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.0" />

--- a/src/Nether.Web/Startup.cs
+++ b/src/Nether.Web/Startup.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using IdentityServer4.Models;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Rewrite;
 
 namespace Nether.Web
 {
@@ -182,6 +183,15 @@ namespace Nether.Web
             ILoggerFactory loggerFactory)
         {
             var logger = loggerFactory.CreateLogger<Startup>();
+
+            bool redirectToHttps = bool.Parse(Configuration["Common:RedirectToHttps"] ?? "false");
+            if (redirectToHttps)
+            {
+                _logger.LogInformation("Enabling RedirectToHttps");
+                var rewriteOptions = new RewriteOptions()
+                                            .AddRedirectToHttps();
+                app.UseRewriter(rewriteOptions);
+            }
 
             var serviceSwitchSettings = app.ApplicationServices.GetRequiredService<NetherServiceSwitchSettings>();
 

--- a/src/Nether.Web/Utilities/ApplicationPerformanceMonitoringExtensions.cs
+++ b/src/Nether.Web/Utilities/ApplicationPerformanceMonitoringExtensions.cs
@@ -62,7 +62,7 @@ namespace Nether.Web.Features.Identity
 
                         services.AddApplicationInsightsTelemetry(options =>
                         {
-                            options.DeveloperMode = hostingEnvironment.EnvironmentName == "Development";
+                            options.DeveloperMode = hostingEnvironment.IsDevelopment();
                             options.InstrumentationKey = instrumentationKey;
                         });
 

--- a/src/Nether.Web/Utilities/ExceptionLoggingFilterAttribute.cs
+++ b/src/Nether.Web/Utilities/ExceptionLoggingFilterAttribute.cs
@@ -30,7 +30,7 @@ namespace Nether.Web.Utilities
         public override void OnException(ExceptionContext context)
         {
             string message;
-            if (_hostingEnvironment.EnvironmentName == "Development")
+            if (_hostingEnvironment.IsDevelopment())
             {
                 // For development, write full exception message to client
                 _logger.LogError("Unhandled exception: {0}", context.Exception);

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -6,7 +6,8 @@
     },
     "ApplicationPerformanceMonitor": {
       "wellknown": "null"
-    }
+    },
+    "RedirectToHttps" : false /* Set true for production */
   },
   "Leaderboard": {
     "Enabled": true,


### PR DESCRIPTION
### Issue: Fixes #410 

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Add config option to issue redirects to HTTPS, as per #410

### Test:
Build and run Nether.Web and check that the default local configuration doesn't perform redirection
Set the RedirectToHttpsOption as per the updated docs, and re-run. Navigating to http://localhost:5000/ should redirect you to https://localhost:5000/ (note that when running locally for development we don't respond to HTTPS so you won't get a page rendered!)