### PR TITLE
Simplify the facebook configuration

### DIFF
--- a/documentation/api/identity/users.md
+++ b/documentation/api/identity/users.md
@@ -69,7 +69,7 @@ Gets details of the user and their logins.
 
 Roles: currently Admin or Player
 
-For `logins`, the `providerType` can currently be: `password` (for username + password flow) or `facebook` for the facebook user access token flow. The `providerId` is the identifier for the user for the given `providerType`. The provider may store additional information (e.g. the password hash for the `password` provider, but the API intentionally doesn't provide this).
+For `logins`, the `providerType` can currently be: `password` (for username + password flow) or `facebook` for the facebook flows. The `providerId` is the identifier for the user for the given `providerType`. The provider may store additional information (e.g. the password hash for the `password` provider, but the API intentionally doesn't provide this).
 
 Issuing a `DELETE` against the `_link` property for a login will remove the login for the user.
 

--- a/documentation/configuration/identity.md
+++ b/documentation/configuration/identity.md
@@ -80,44 +80,33 @@ RequireHttps | bool | True to require HTTPS, False to allow insecure connections
 To configure the sign-in methods that can be used, modify the `SignInMethods` as shown below.
 
 Currently supported methods:
-* [Facebook](#facebook) - in-browser, interactive Facebook login
-* [FacebookUserAccessToken](#facebookuseraccesstoken) - supports token translation from a Facebook user access token to a Nether token
+* [Facebook](#facebook)
+
+
+### Facebook
+
+To use this sign-in method you need to create a Facebook App at https://developers.facebook.com/apps/. There is a walkthrough of [creating a Facebook application](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins). When setting the `Valid OAuth Redirect URIs` set this to `http://localhost:5000/identity/signin-facebook` (or the URL for your published site)
 
 
 ```json
   "Identity" : {
       "SignInMethods": {
-            // Facebook in-browser, interactive flow
             "Facebook": {
-                "Enabled": false,
+                "EnableImplicit": true, // Facebook in-browser, interactive flow
+                "EnableAccessToken": true, // the custom facebook token flow (e.g. from Unity)
                 "AppId": "",
                 "AppSecret": ""
-            },
-            // the custom facebook token flow (e.g. from Unity)
-            "FacebookUserAccessToken": {
-                "Enabled": false,
-                "AppToken": ""
             }
       }
   }
 ```
 
-### Facebook
-To use this sign-in method you need to create a Facebook App at https://developers.facebook.com/apps/. There is a walkthrough of [creating a Facebook application](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins). When setting the `Valid OAuth Redirect URIs` set this to `http://localhost:5000/identity/signin-facebook` (or the URL for your published site)
-
 Property name | Type | Description
 --------------|------|------------
-Enabled | bool | True to enable this login method|
+EnableImplicit | bool | True to enable the implicit (in-browser) login flow|
+EnableAccessToken | bool | True to enable the custom token grant flow (e.g. for use from Unity)
 AppId | string | The AppId for your Facebook app from https://developers.facebook.com/apps
 AppSecret | string | The AppSecret for your Facebook app from https://developers.facebook.com/apps
-
-### FacebookUserAccessToken
-To use this sign-in method you need to create a Facebook App at https://developers.facebook.com/apps/. There is a walkthrough of [creating a Facebook application](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins). 
-
-Property name | Type | Description
---------------|------|------------
-Enabled | bool | True to enable this login method|
-AppToken | string | The AppToken for your Facebook app from https://developers.facebook.com/tools/accesstoken
 
 
 ## Clients

--- a/documentation/devsetup.md
+++ b/documentation/devsetup.md
@@ -32,23 +32,7 @@ We support and plan to build SDKs for [Unity](http://unity3d.com). However, sinc
 
 Nether has been built using ASP.NET Core with a pluggable identity system. Currently, there is support for Facebook authentication (more to follow). To get set up with Facebook authentication you need to register an application with Facebook then configure it for use by your instance of Nether.
 
-Setting up your Facebook application has been documented in the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins). Complete that process to obtain your Facebook Application Token (AppToken).
-
-Once you've recieved your token, you have two options for making it available to your Nether application. The simple way is to add the value in the `appsettings.json`. However, this approach runs the risk of accidently committing your AppToken secret to a (possibly public) repository.
-
-Alternatively, you can set the `Facebook:AppToken` or `Facebook__AppToken` environment variable:
-
-```powershell
-    # PowerShell
-    ${env:Facebook:AppToken} = "<your token here>"
-```
-
-```bash
-    # bash
-    export Facebook__AppToken=<your token here>
-```
-
-For more details on configuring the identity system see the [Nether identity configuration docs](identity/configuration.md).
+For more details on configuring the identity system see the [Nether identity configuration docs](configuration/identity.md).
 
 ## Building and running Nether
 

--- a/documentation/identity/readme.md
+++ b/documentation/identity/readme.md
@@ -6,30 +6,8 @@ Any game developer should be able to add Identity support easily into their game
 WARNING: The identity implementation in still under development, so expect these details to change :-)
 
 ### Configuring facebook authentication
-To configure the project to use facebook authentication you need to set up an application in facebook. The ASP.NET Core documentation [walks through this process](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/facebook-logins#creating-the-app-in-facebook). Follow the "Creating the app in facebook" section of that documentation, and then save the `App Token` from [Access Token Tool](https://developers.facebook.com/tools/accesstoken) in configuration.
 
-appsettings.json
-
-```json
- "Identity" : {
-    "Facebook": {
-      "AppToken": "<your token>"
-    }
- }
-```
-
-Or set environment variables:
-
-```powershell
- # powershell
- ${env:Identity:Facebook:AppToken} = "<your token>"
-```
-
-
-```bash
- # bash
-export Identity__Facebook__AppToken="<your token>"
-```
+Information on configuring facebook sign in is in the [configuration docs](../configuration/identity.md)
 
 ### Configuring users
 The Users and Logins APIs allow you to programmatically add users. Additionally, the facebook custom flow creates users in the player role based on a facebook user acces token.

--- a/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
+++ b/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
@@ -80,7 +80,7 @@ namespace Nether.Web.Features.Identity
                 .AddInMemoryApiResources(Scopes.GetApiResources())
             ;
 
-            var facebookUserAccessTokenEnabled = bool.Parse(configuration["Identity:SignInMethods:FacebookUserAccessToken:Enabled"] ?? "false");
+            var facebookUserAccessTokenEnabled = bool.Parse(configuration["Identity:SignInMethods:Facebook:EnableAccessToken"] ?? "false");
             if (facebookUserAccessTokenEnabled)
             {
                 identityServerBuilder.AddExtensionGrantValidator<FacebookUserAccessTokenExtensionGrantValidator>();

--- a/src/Nether.Web/Startup.cs
+++ b/src/Nether.Web/Startup.cs
@@ -232,7 +232,7 @@ namespace Nether.Web
                         AutomaticChallenge = false
                     });
 
-                    var facebookEnabled = bool.Parse(Configuration["Identity:SignInMethods:Facebook:Enabled"] ?? "false");
+                    var facebookEnabled = bool.Parse(Configuration["Identity:SignInMethods:Facebook:EnableImplicit"] ?? "false");
                     if (facebookEnabled)
                     {
                         var appId = Configuration["Identity:SignInMethods:Facebook:AppId"];

--- a/src/Nether.Web/appsettings.json
+++ b/src/Nether.Web/appsettings.json
@@ -76,18 +76,12 @@
       "UiBaseUrl": "http://localhost:5000/ui"
     },
     "SignInMethods": {
-      // Facebook in-browser, interactive flow
       "Facebook": {
-        "Enabled": false,
+        "EnableImplicit": false, // Facebook in-browser, interactive flow
+        "EnableAccessToken" : false, // the custom facebook token flow (e.g. from Unity)
         "AppId": "",
         "AppSecret": ""
-      },
-      // the custom facebook token flow (e.g. from Unity)
-      "FacebookUserAccessToken": {
-        "Enabled": false,
-        "AppToken": ""
       }
-      // TODO - generic OpenIdConnect, ...
     },
     "Clients": {
       // TODO - client secrets should be recreated when deploying!


### PR DESCRIPTION
### Issue: closes #419

 - [X] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Simplifies the configuration for facebook authentication. You no longer have to provide appId + secret for one set of config, and appToken for another. Now it is combined under a single section with appId and secret, and two switches for the different flows

### Test:
Configure Nether.Web for facebook authentication as per the updated docs and verify that logging in via facebook works