### PR TITLE
[WIP] Persist temporary identity cert 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,6 @@ paket-files/
 *.privateparams.json
 
 appsettings.json
+
+# runtime generated files
+**/runtime-artifacts/

--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -1,5 +1,7 @@
 $netherRoot = $PSScriptRoot
 
+$ErrorActionPreference = "Stop"
+
 function RunIntegrationTests() {
     # launch Nether.Web
     Start-Process powershell "$netherRoot\rundev.ps1 > '$netherRoot\nether.web.log'"
@@ -61,8 +63,9 @@ function RenameWithRetry($filename, $newfilename) {
         } 
         catch {
             Write-Host "Rename failed... retrying"
-         }
+        }
         Start-Sleep -Seconds 1
+        $count += 1
     }
     Write-Host "Rename faild!"
     exit -100
@@ -88,6 +91,7 @@ RenameWithRetry "$netherRoot\nether.web.log" "$netherRoot\nether.web-inmemory.lo
 Push-AppveyorArtifact "$netherRoot\nether.web-inmemory.log" -FileName nether.web-inmemory.txt
 
 if ($status -ne 0) {
+    Write-Host "Exiting with status $status"
     exit $status
 }
 
@@ -103,5 +107,6 @@ RenameWithRetry "$netherRoot\nether.web.log" "$netherRoot\nether.web-sql.log"
 Push-AppveyorArtifact "$netherRoot\nether.web-sql.log" -FileName nether.web-sql.txt
 
 if ($status -ne 0) {
+    Write-Host "Exiting with status $status"
     exit $status
 }

--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -67,6 +67,8 @@ Write-Host "******************"
 Write-Host "*** Running integration tests: in-memory"
 $status = RunIntegrationTests
 
+# kill the web server (brute force - killing all dotnet processes!)
+Stop-Process -Name dotnet
 Rename-Item "$netherRoot\nether.web.log" "$netherRoot\nether.web-inmemory.log"
 Push-AppveyorArtifact "$netherRoot\nether.web-inmemory.log" -FileName nether.web-inmemory.txt
 
@@ -74,17 +76,16 @@ if ($status -ne 0){
     exit $status
 }
 
-# kill the web server (brute force - killing all dotnet processes!)
-Stop-Process -Name dotnet
 
 ConfigureSqlServer
 Write-Host "******************"
 Write-Host "*** Running integration tests: SQL Server"
 $status = RunIntegrationTests
 
+# kill the web server (brute force - killing all dotnet processes!)
+Stop-Process -Name dotnet
 Rename-Item "$netherRoot\nether.web.log" "$netherRoot\nether.web-sql.log"
 Push-AppveyorArtifact "$netherRoot\nether.web-sql.log" -FileName nether.web-sql.txt
-
 
 if ($status -ne 0){
     exit $status

--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -52,6 +52,21 @@ function ConfigureSqlServer() {
     ${env:Analytics:Store:properties:ConnectionString} = "Server=(local)\SQL2016;Database=nether;User ID=sa;Password=Password12!"
 }
 
+function RenameWithRetry($filename, $newfilename) {
+    $count = 0
+    while ($count -lt 10) {
+        try {
+            Rename-Item $filename $newfilename
+            return
+        } 
+        catch {
+            Write-Host "Rename failed... retrying"
+         }
+        Start-Sleep -Seconds 1
+    }
+    Write-Host "Rename faild!"
+    exit -100
+}
 Write-Host "***************************************************************************"
 Write-Host " _       _                       _   _               _            _"
 Write-Host "(_)_ __ | |_ ___  __ _ _ __ __ _| |_(_) ___  _ __   | |_ ___  ___| |_ ___"
@@ -69,10 +84,10 @@ $status = RunIntegrationTests
 
 # kill the web server (brute force - killing all dotnet processes!)
 Stop-Process -Name dotnet
-Rename-Item "$netherRoot\nether.web.log" "$netherRoot\nether.web-inmemory.log"
+RenameWithRetry "$netherRoot\nether.web.log" "$netherRoot\nether.web-inmemory.log"
 Push-AppveyorArtifact "$netherRoot\nether.web-inmemory.log" -FileName nether.web-inmemory.txt
 
-if ($status -ne 0){
+if ($status -ne 0) {
     exit $status
 }
 
@@ -84,9 +99,9 @@ $status = RunIntegrationTests
 
 # kill the web server (brute force - killing all dotnet processes!)
 Stop-Process -Name dotnet
-Rename-Item "$netherRoot\nether.web.log" "$netherRoot\nether.web-sql.log"
+RenameWithRetry "$netherRoot\nether.web.log" "$netherRoot\nether.web-sql.log"
 Push-AppveyorArtifact "$netherRoot\nether.web-sql.log" -FileName nether.web-sql.txt
 
-if ($status -ne 0){
+if ($status -ne 0) {
     exit $status
 }

--- a/appveyor-run-with-integration-tests.ps1
+++ b/appveyor-run-with-integration-tests.ps1
@@ -64,10 +64,10 @@ function RenameWithRetry($filename, $newfilename) {
         catch {
             Write-Host "Rename failed... retrying"
         }
-        Start-Sleep -Seconds 1
+        Start-Sleep -Seconds 5
         $count += 1
     }
-    Write-Host "Rename faild!"
+    Write-Host "Rename failed!"
     exit -100
 }
 Write-Host "***************************************************************************"
@@ -84,11 +84,12 @@ Write-Host "********************************************************************
 Write-Host "******************"
 Write-Host "*** Running integration tests: in-memory"
 $status = RunIntegrationTests
+Write-Host "*** Tests completed with status '$status'"
 
 # kill the web server (brute force - killing all dotnet processes!)
 Stop-Process -Name dotnet
 RenameWithRetry "$netherRoot\nether.web.log" "$netherRoot\nether.web-inmemory.log"
-Push-AppveyorArtifact "$netherRoot\nether.web-inmemory.log" -FileName nether.web-inmemory.txt
+# Push-AppveyorArtifact "$netherRoot\nether.web-inmemory.log" -FileName nether.web-inmemory.txt
 
 if ($status -ne 0) {
     Write-Host "Exiting with status $status"
@@ -100,6 +101,7 @@ ConfigureSqlServer
 Write-Host "******************"
 Write-Host "*** Running integration tests: SQL Server"
 $status = RunIntegrationTests
+Write-Host "*** Tests completed with status '$status'"
 
 # kill the web server (brute force - killing all dotnet processes!)
 Stop-Process -Name dotnet

--- a/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
+++ b/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
@@ -74,7 +74,7 @@ namespace Nether.Web.Features.Identity
                     options.Endpoints.EnableTokenEndpoint = true;
                     options.UserInteraction.ErrorUrl = "/account/error";
                 })
-                .AddTemporarySigningCredential() // using inbuilt signing cert, but we are explicitly a dev-only service at this point ;-)
+                .AddDeveloperSigningCredential(filename: "runtime-artifacts/identity-cert") // using temporary signing cert, but we are explicitly a dev-only service at this point ;-)
                 .AddInMemoryClients(clients)
                 .AddInMemoryIdentityResources(Scopes.GetIdentityResources())
                 .AddInMemoryApiResources(Scopes.GetApiResources())

--- a/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
+++ b/src/Nether.Web/Features/Identity/IdentityServiceExtensions.cs
@@ -15,6 +15,7 @@ using IdentityServer4.Validation;
 using Nether.Common.DependencyInjection;
 using Nether.Web.Features.Identity.Configuration;
 using Nether.Web.Utilities;
+using System.IO;
 
 namespace Nether.Web.Features.Identity
 {
@@ -64,6 +65,10 @@ namespace Nether.Web.Features.Identity
                 throw new NotSupportedException($"The Identity Server configuration is currently only intended for Development environments. Current environment: '{hostingEnvironment.EnvironmentName}'");
             }
 
+            if (!Directory.Exists("runtime-artifacts"))
+            {
+                Directory.CreateDirectory("runtime-artifacts");
+            }
             var clientSource = new ConfigurationBasedClientSource(logger);
             var clients = clientSource.LoadClients(configuration.GetSection("Identity:Clients"))
                                 .ToList();


### PR DESCRIPTION
### Issue: #257

 - [ ] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Persist the generated temporary identity certificate to disk and re-use it if it exists on startup.

Whilst this doesn't enable specifying custom certificates for production, this change should make identity a little more stable as the same certificate will be used across instances of Nether.Web

### Test:
1.Start Nether.Web
2. Load SwaggerUI and authorise
3. Make a call via SwaggerUI and keep the browser tab open
4. Restart Nether.Web
5. Make another call in the same SwaggerUI tab and verify that it succeeds (without requiring re-authorisation)