### PR TITLE
Fixed url to Nether Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Nether Logo](https://github.com/MicrosoftDX/nether/blob/master/logos/both-logo-and-title/logo-title-1109x256.png)
+![Nether Logo](https://raw.githubusercontent.com/MicrosoftDX/nether/master/logos/both-logo-and-title/logo-title-1109x256.png)
 # Building blocks for gaming on Azure
 
 master branch status


### PR DESCRIPTION
If Nether GitHub page is embedded in another web site, like they do at MyGet.org, then the logo for Nether didn't show up since the old URL in the README.md file didn't point to the raw logo file, but rather inside the repository. This PR fixes that problem and makes the site look great again.

TEST: Just have a look at the README.md file and make sure the logo still looks great. That's it! :-)