### PR TITLE
Free tier

### DIFF
--- a/deployment/nether-deploy-db.json
+++ b/deployment/nether-deploy-db.json
@@ -19,6 +19,7 @@
             "type": "string", 
             "defaultValue": "Basic", 
             "allowedValues": [ 
+                "Free",
                 "Basic", 
                 "Standard", 
                 "Standard S1", 
@@ -55,6 +56,10 @@
         "databaseName": "nether",
         /* The databaseSKU specified in the input parameter is translated into the proper edition via this array */
         "databasePricingTiers" : {
+            "Free" : {
+                "edition": "Free",
+                "requestedServiceObjectiveName": "Free"
+            },
             "Basic" : {
                 "edition": "Basic",
                 "requestedServiceObjectiveName": "Basic"

--- a/deployment/nether-deploy-db.json
+++ b/deployment/nether-deploy-db.json
@@ -17,7 +17,7 @@
         },
         "databaseSKU": { 
             "type": "string", 
-            "defaultValue": "Basic", 
+            "defaultValue": "Free", 
             "allowedValues": [ 
                 "Free",
                 "Basic", 

--- a/deployment/nether-deploy-eventhub.json
+++ b/deployment/nether-deploy-eventhub.json
@@ -60,7 +60,7 @@
             "minValue": 1,
             "maxValue": 7,
             "metadata": {
-                "description": "For basic teir this must be 1. For standard tier this can be 1-7"
+                "description": "For basic tier this must be 1. For standard tier this can be 1-7"
             }
         },
         "PartitionCount": {

--- a/deployment/nether-deploy.json
+++ b/deployment/nether-deploy.json
@@ -71,6 +71,7 @@
             "type": "string", 
             "defaultValue": "Basic", 
             "allowedValues": [ 
+                "Free",
                 "Basic", 
                 "Standard", 
                 "Standard S1", 


### PR DESCRIPTION
### Issue: Fixes #417 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Added a new tier into the supported values of the Database SKU across the deployments scripts, and defaulted to Free tier to allow Quickstart to default to the Free SQL tier.

### Test:
Upload the deployment scripts to a publicly accessible location (i.e. Azure Storage), and invoke Azure's deployment magic by changing the URL: https://portal.azure.com/#create/Microsoft.Template/uri/{uri encoded url to the nether-deploy.json file}

The quick-start version (nether-deploy-quickstart) should default to Free tier with the DB when deployed, and the _regular_ deploy script will default to Basic, but allow Free tier selection.