### PR TITLE
Pinned .NET SDK to 1.0.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src", "tests" ],
+  "sdk": {
+    "version": "1.0.3"
+  }
+}


### PR DESCRIPTION
Added global.json file that will pin .NET SDK to 1.0.3 in folders: src and tests. This is to avoid problems now that newer test version of .NET Core are out that we haven't yet tried or don't yet support.