### PR TITLE
FileOutputManager - handle non header messages

### DIFF
--- a/src/Nether.Analytics/FileOutputManager.cs
+++ b/src/Nether.Analytics/FileOutputManager.cs
@@ -39,6 +39,10 @@ namespace Nether.Analytics
             }
             else
             {
+                if (!File.Exists(filePath))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+                }
                 await AppendMessageToFileAsync(serializedMessage, filePath);
             }
         }

--- a/src/Nether.Analytics/FileOutputManager.cs
+++ b/src/Nether.Analytics/FileOutputManager.cs
@@ -40,9 +40,8 @@ namespace Nether.Analytics
             else
             {
                 await AppendMessageToFileWithoutHeaderAsync(serializedMessage, filePath);
-                              
             }
-        }        
+        }
 
         private string GetFilePath(string pipelineName, int idx, Message msg)
         {
@@ -57,7 +56,7 @@ namespace Nether.Analytics
             // If we don't need to take into consideration of the header row in the files
             // just use the following simple implementation for writing to the file
             using (StreamWriter stream = File.AppendText(filePath))
-            {                
+            {
                 await stream.WriteAsync(serializedMessage);
             }
         }
@@ -83,7 +82,7 @@ namespace Nether.Analytics
                         string header = $"{_serializer.Header}{Environment.NewLine}";
                         await AppendMessageToFileAsync(header, filePath);
                     }
-                }                              
+                }
                 catch (Exception e)
                 {
                     // it is possible that another thread is now creating the file and adding the header
@@ -105,8 +104,8 @@ namespace Nether.Analytics
                     tryAgain = false;
                 }
                 catch (DirectoryNotFoundException e)
-                {                    
-                    Directory.CreateDirectory(Path.GetDirectoryName(filePath));                   
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(filePath));
                 }
                 catch (Exception e)
                 {

--- a/src/Nether.Analytics/FileOutputManager.cs
+++ b/src/Nether.Analytics/FileOutputManager.cs
@@ -83,7 +83,7 @@ namespace Nether.Analytics
                         await AppendMessageToFileAsync(header, filePath);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // it is possible that another thread is now creating the file and adding the header
                     // wait a while before continue to try and write the file
@@ -103,13 +103,13 @@ namespace Nether.Analytics
                     await AppendMessageToFileAsync(serializedMessage, filePath);
                     tryAgain = false;
                 }
-                catch (DirectoryNotFoundException e)
+                catch (DirectoryNotFoundException)
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    // it is possible that another thread is now creating the file and adding the header
+                    // it is possible that another thread is now creating the file 
                     // wait a while before continue to try and write the file
                     await Task.Delay(1000);
                 }


### PR DESCRIPTION
### Issue: #475 

 - [x] Tick here to confirm that you have run RunCodeFormatter.ps1

### Description:
Fix bug with no header messages
### Test:
Add a fileOutputManager and use a serialiser with no header. 