### PR TITLE
Fixed broken URL in player-management config doc

### DIFF
--- a/documentation/configuration/player-management.md
+++ b/documentation/configuration/player-management.md
@@ -1,6 +1,6 @@
 # Player Management
 
-Player Management functionality, implementing Nether [Player Management APIs](../api/players/README.md), using SQL Database as a data store.
+Player Management functionality, implementing Nether [Player Management APIs](../api/player-management/README.md), using SQL Database as a data store.
 
 ## Prerequisites
 * SQL Database - [learn how to create a SQL Database](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-get-started)


### PR DESCRIPTION
### Issue: #137 

### Description:
In the Player Management config documentation, the link to the Player Management API documentation was broken/incorrect.

Changed "players" in URL to "player-management"

### Test:
The link should work now in the document.