### PR TITLE
Fixed bug in top-n leaderboard

### DIFF
--- a/src/cloud/functions/leaderboards/top-n/leaderboard/run.csx
+++ b/src/cloud/functions/leaderboards/top-n/leaderboard/run.csx
@@ -67,7 +67,7 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
         {
             // Update rank to i + 1 if score is not the same as the last player's score
             // i.e. two or more players with the same score should have the same rank
-            if (i > 0 || leaders[i-1].Score != leaders[i].Score)
+            if (i > 0 && leaders[i-1].Score != leaders[i].Score)
                 rank = i + 1;
 
             leaders[i].Rank = rank;


### PR DESCRIPTION
### Issue: #613 

Error was due to incorrect if statement that used "or" expression instead of the required "and"