### PR TITLE
Timestamp added to score on top-n scenario

### DIFF
--- a/src/cloud/functions/leaderboards/around-me/leaderboard/run.csx
+++ b/src/cloud/functions/leaderboards/around-me/leaderboard/run.csx
@@ -118,7 +118,7 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, string
         {
             foreach (ScoreItem scr in sortedListPositionsBelowCurrent)
             {
-                sortedResult.Add(new LeaderboardItem { Rank = 0, Player = scr.Player, Score = scr.Score });
+                sortedResult.Add(new LeaderboardItem { Rank = 0, Player = scr.Player, Timestamp = src.Timestamp, Score = scr.Score });
             }
         }
 
@@ -171,6 +171,8 @@ public class ScoreItem
     public string Player { get; set; }
     [JsonProperty(PropertyName = "playerId")]
     public string PlayerId { get; set; }
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set; }
 }
@@ -181,6 +183,8 @@ public class LeaderboardItem
     public int Rank { get; set; }
     [JsonProperty(PropertyName = "player")]
     public string Player { get; set; }
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set; }
 }

--- a/src/cloud/functions/leaderboards/around-me/score/run.csx
+++ b/src/cloud/functions/leaderboards/around-me/score/run.csx
@@ -200,15 +200,17 @@ public static int NumberWithSameScores(List<LeaderboardItem> listToRank, int sta
 public class ScoreItem
 {
     [JsonProperty(PropertyName = "id")]
-    public string Id { get; set; }
+    public string Id { get; set;}    
     [JsonProperty(PropertyName = "leaderboard")]
-    public string Leaderboard { get; set; }
+    public string Leaderboard { get; set;}    
     [JsonProperty(PropertyName = "player")]
-    public string Player { get; set; }
+    public string Player { get; set;}
     [JsonProperty(PropertyName = "playerId")]
-    public string PlayerId { get; set; }
+    public string PlayerId { get; set;}
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
-    public double Score { get; set; }
+    public double Score { get; set;}
 }
 
 public class LeaderboardItem
@@ -217,6 +219,8 @@ public class LeaderboardItem
     public int Rank { get; set; }
     [JsonProperty(PropertyName = "player")]
     public string Player { get; set; }
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set; }
 }

--- a/src/cloud/functions/leaderboards/top-n/leaderboard/run.csx
+++ b/src/cloud/functions/leaderboards/top-n/leaderboard/run.csx
@@ -58,7 +58,7 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
         var query = 
             (from s in leaderboard
             orderby s.Score descending
-            select new LeaderboardItem {Player = s.Player, Score = s.Score}).Take(lengthOfLeaderboard);
+            select new LeaderboardItem {Player = s.Player, Timestamp = s.Timestamp, Score = s.Score}).Take(lengthOfLeaderboard);
 
         var leaders = query.ToList();
 
@@ -98,6 +98,8 @@ public class ScoreItem
     public string Player { get; set;}
     [JsonProperty(PropertyName = "playerId")]
     public string PlayerId { get; set;}
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set;}
 }
@@ -108,6 +110,8 @@ public class LeaderboardItem
     public int Rank { get; set; }
     [JsonProperty(PropertyName = "player")]
     public string Player { get; set; }
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set; }
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set; }
 }

--- a/src/cloud/functions/leaderboards/top-n/score/run.csx
+++ b/src/cloud/functions/leaderboards/top-n/score/run.csx
@@ -59,6 +59,7 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
     postedScore.PlayerId = data?.playerId;
     postedScore.Player = data?.player;
     postedScore.Score = data?.score;
+    postedScore.Timestamp = DateTime.UtcNow;
 
     try
     {
@@ -84,6 +85,7 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
                 if (postedScore.Score>existingPlayer.Score)
                 {
                     existingPlayer.Score = postedScore.Score;
+                    existingPlayer.Timestamp = postedScore.Timestamp;
                     await client.ReplaceDocumentAsync(UriFactory.CreateDocumentUri(db, collection, existingPlayer.Id), postedScore);
                     return req.CreateResponse(HttpStatusCode.OK, $"The score  for user {existingPlayer.PlayerId} has been updated to {postedScore.Score}");
                 } 
@@ -107,6 +109,8 @@ public class ScoreItem
     public string Player { get; set;}
     [JsonProperty(PropertyName = "playerId")]
     public string PlayerId { get; set;}
+    [JsonProperty(PropertyName = "timestamp")]
+    public DateTime Timestamp { get; set;}
     [JsonProperty(PropertyName = "score")]
     public double Score { get; set;}
 }

--- a/src/cloud/functions/leaderboards/top-n/score/sample.dat
+++ b/src/cloud/functions/leaderboards/top-n/score/sample.dat
@@ -2,6 +2,5 @@
     "leaderboard": "level1",
     "player": "mario",
     "playerId": "1337",
-    "timestamp": 1234,
     "score": 420
 }

--- a/src/cloud/functions/leaderboards/top-n/score/sample.dat
+++ b/src/cloud/functions/leaderboards/top-n/score/sample.dat
@@ -2,5 +2,6 @@
     "leaderboard": "level1",
     "player": "mario",
     "playerId": "1337",
+    "timestamp": 1234,
     "score": 420
 }


### PR DESCRIPTION
### Issue: #615 
 - [ ] Tick here to confirm that you have run RunCodeFormatter.ps1
Sorry, not done this don't know how??

### Description:
Added a Timestamp to the Score in top-n and around-me scenario's. Automatically set in Score function to UtcNow and returned in output in Leaderboard functions.

### Test:
Add a score and get the leaderboard. See the timestamp in the output.

